### PR TITLE
#119: Disable dd 20 schema validation for selected items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ schema-validation-report.json
 *.swp
 results/
 *.resoscript
+schema-validation-settings.json

--- a/lib/schema/index.js
+++ b/lib/schema/index.js
@@ -8,6 +8,7 @@ const { getReferenceMetadata } = require('@reso/reso-certification-etl');
 const { processFiles, createDirectoryIfNotPresent, writeFile, readFile } = require('./utils');
 
 const ERROR_REPORT = 'schema-validation-report.json';
+const VALIDATION_CONFIG_FILE = 'schema-validation-settings.json';
 
 /**
  * @param {Object} obj
@@ -80,6 +81,8 @@ const schema = async ({
         handleError('Invalid path to payloads');
       }
 
+      const validationConfig = JSON.parse(await readFile(VALIDATION_CONFIG_FILE)) || {};
+
       try {
         const fileContentsMap = {};
         await processFiles({ inputPath: payloadPath, fileContentsMap });
@@ -89,7 +92,8 @@ const schema = async ({
           fileContentsMap,
           additionalProperties,
           version,
-          resourceName
+          resourceName,
+          validationConfig
         });
       } catch (err) {
         handleError(err);
@@ -134,10 +138,18 @@ const generateSchemaFromMetadata = async ({ metadataPath = '', additionalPropert
  * @param {{}} obj.fileContentsMap
  * @param {string} obj.version
  * @param {string} obj.resourceName
+ * @param {Object} obj.validationConfig
  *
  * @description Reads the directory with the flattened JSON files and sends them for validation.
  */
-const validatePayloads = async ({ metadataPath = '', fileContentsMap = {}, additionalProperties = false, version, resourceName }) => {
+const validatePayloads = async ({
+  metadataPath = '',
+  fileContentsMap = {},
+  additionalProperties = false,
+  version,
+  resourceName,
+  validationConfig = {}
+}) => {
   if (!Object.keys(fileContentsMap).length) throw new Error('No JSON files found');
 
   await validatePayloadAndGenerateResults({
@@ -146,7 +158,8 @@ const validatePayloads = async ({ metadataPath = '', fileContentsMap = {}, addit
     version,
     metadataPath,
     additionalProperties,
-    resourceName
+    resourceName,
+    validationConfig
   });
 };
 
@@ -158,7 +171,8 @@ const validatePayloads = async ({ metadataPath = '', fileContentsMap = {}, addit
  * @param {string} obj.version
  * @param {string} obj.metadataPath
  * @param {string} obj.resourceName
- * @param {{}} obj.fileContentsMap
+ * @param {Object} obj.fileContentsMap
+ * @param {Object} obj.validationConfig
  *
  * @description Processes the input from the CLI and writes the final error report into the given path.
  */
@@ -168,7 +182,8 @@ const validatePayloadAndGenerateResults = async ({
   version,
   metadataPath,
   additionalProperties,
-  resourceName
+  resourceName,
+  validationConfig = {}
 }) => {
   try {
     let schemaJson = null;
@@ -191,7 +206,8 @@ const validatePayloadAndGenerateResults = async ({
       payloads: fileContentsMap,
       schema: schemaJson,
       resourceNameFromArgs: resourceName,
-      versionFromArgs: version
+      versionFromArgs: version,
+      validationConfig
     });
 
     if (result?.errors) {

--- a/lib/schema/validate.js
+++ b/lib/schema/validate.js
@@ -10,6 +10,7 @@ const { parseNestedPropertyForResourceAndField } = require('./utils');
 const VALIDATION_ERROR_MESSAGES = Object.freeze({
   NO_CONTEXT_PROPERTY: 'No properties were found in the payload that match "@reso.context"'
 });
+const IGNORE_ENUMS = 'ignoreEnumerations';
 
 const buildEnumMap = (enums = []) =>
   enums.reduce((acc, curr) => {
@@ -151,6 +152,7 @@ const isValidDataDictionaryVersion = (version = '') => getValidDataDictionaryVer
  * @param {{}} obj.jsonPayload
  * @param {{}} obj.errorMap
  * @param {Boolean?} obj.isResoDataDictionarySchema
+ * @param {Object} obj.validationConfig
  *
  * @returns Intermediate error and warning caches along with stats. Can be combined later using `combineErrors`
  */
@@ -161,7 +163,8 @@ const validate = ({
   errorMap = {},
   fileName = '',
   version,
-  isResoDataDictionarySchema = false /*CLI only */
+  isResoDataDictionarySchema = false /*CLI only */,
+  validationConfig = {}
 } = {}) => {
   const { stats = { totalErrors: 0, totalWarnings: 0 }, cache = {}, errorCache = {}, warningsCache = {}, payloadErrors = {} } = errorMap;
   const schema = jsonSchema;
@@ -265,6 +268,18 @@ const validate = ({
       const invalidEnums = parsedLookupValue.filter(v => !enumMap[v]);
       if (invalidEnums.length) {
         const [resource] = nesting;
+        if (validationConfig?.[version]?.[resource]?.[field]?.[IGNORE_ENUMS]) {
+          return invalidEnums.map(e => {
+            const ajvLikeError = {
+              instancePath: payload.value ? `0/value/1/${resource}/1/${field}` : `0/${resource}/0/${field}`,
+              failedItemValue: e,
+              message: `The following enumerations in the ${field} Field were not advertised. This will fail in Data Dictionary 2.1`,
+              keyword: 'enum',
+              isWarning: true
+            };
+            return ajvLikeError;
+          });
+        }
         return invalidEnums.map(e => {
           const ajvLikeError = {
             instancePath: payload.value ? `0/value/1/${resource}/1/${field}` : `0/${resource}/0/${field}`,
@@ -341,10 +356,11 @@ const validate = ({
  * @param {{}} obj.schema
  * @param {string} obj.resourceNameFromArgs
  * @param {string} obj.versionFromArgs
+ * @param {Object} obj.validationConfig
  *
  * @returns The processed error report
  */
-const validatePayload = ({ payloads = {}, schema, resourceNameFromArgs = '', versionFromArgs }) => {
+const validatePayload = ({ payloads = {}, schema, resourceNameFromArgs = '', versionFromArgs, validationConfig = {} }) => {
   const payloadErrors = {};
   const cache = {};
   const errorCache = {};
@@ -373,7 +389,8 @@ const validatePayload = ({ payloads = {}, schema, resourceNameFromArgs = '', ver
       errorMap,
       jsonSchema: isResoDataDictionarySchema ? schema.get(version) : schema,
       resourceName: resourceNameFromArgs,
-      isResoDataDictionarySchema
+      isResoDataDictionarySchema,
+      validationConfig
     });
   });
 
@@ -448,11 +465,15 @@ const combineErrors = ({ cache, errorCache, warningsCache, payloadErrors, stats 
                 occurrences: fileNames.map(fname => ({
                   count: files[fname].occurrences,
                   ...(() => {
-                    if (fileNames[0] !== '') {
-                      return { fileName: fname };
-                    } else {
-                      return {};
+                    const [f, l] = fname.split('__');
+                    const result = {};
+                    if (f !== '') {
+                      result.fileName = f;
                     }
+                    if (l !== '') {
+                      result.lookupValue = l;
+                    }
+                    return result;
                   })()
                 }))
               }
@@ -539,19 +560,25 @@ const generateErrorReport = ({
   isResoDataDictionarySchema
 }) => {
   const convertToWarnings = ['maxLength'];
-  validate.errors.reduce((acc, { instancePath, message, keyword, params, failedItemValue: value }) => {
+  validate.errors.reduce((acc, { instancePath, message, keyword, params, failedItemValue: value, isWarning }) => {
     let rName = resourceName;
     if (!instancePath && keyword !== 'additionalProperties') return acc;
     const nestedPayloadProperties = instancePath?.split('/')?.slice(1) || [];
 
-    let failedItemValue =
-      value ??
-      (keyword === 'enum'
-        ? nestedPayloadProperties.reduce((val, curr) => {
-          if (!val && json[curr] !== undefined) return json[curr];
-          return val?.[curr] || val;
-        }, null)
-        : '');
+    let failedItemValue = (() => {
+      if (value === undefined && value === null) {
+        if (keyword === 'enum') {
+          return nestedPayloadProperties.reduce((val, curr) => {
+            if (!val && json[curr] !== undefined) return json[curr];
+            return val?.[curr] || val;
+          }, null);
+        } else {
+          return '';
+        }
+      } else {
+        return value;
+      }
+    })();
 
     const { fieldName, resourceName: resource } = parseNestedPropertyForResourceAndField({
       arr: nestedPayloadProperties,
@@ -600,8 +627,8 @@ const generateErrorReport = ({
       cache[rName][failedItemName] = {};
     }
 
-    if (convertToWarnings.includes(resolvedKeyword) && additionalPropertiesAllowed) {
-      updateWarningsCache({ warningsCache, resourceName: rName, failedItemName, message, fileName, stats });
+    if ((convertToWarnings.includes(resolvedKeyword) && additionalPropertiesAllowed) || isWarning) {
+      updateWarningsCache({ warningsCache, resourceName: rName, failedItemName, message, fileName, stats, failedItemValue });
       return acc;
     }
 
@@ -679,13 +706,14 @@ const updateErrorCache = ({ errorCache, resourceName, failedItemName, message, f
  * @param {{}} obj.warningsCache
  * @param {String} obj.resourceName
  * @param {String} obj.failedItemName
+ * @param {String} obj.failedItemValue
  * @param {String} obj.message
  * @param {String} obj.fileName
  * @param {{totalWarnings: Number}} obj.stats
  *
  * Updates the cache with a new warning message
  */
-const updateWarningsCache = ({ warningsCache, resourceName, failedItemName, message, fileName, stats }) => {
+const updateWarningsCache = ({ warningsCache, resourceName, failedItemName, message, fileName, stats, failedItemValue }) => {
   if (!warningsCache[resourceName]) {
     warningsCache[resourceName] = {};
   }
@@ -697,13 +725,15 @@ const updateWarningsCache = ({ warningsCache, resourceName, failedItemName, mess
   if (!warningsCache[resourceName][failedItemName][`__${message}`]) {
     warningsCache[resourceName][failedItemName][`__${message}`] = {};
   }
-  if (!warningsCache[resourceName][failedItemName][`__${message}`][fileName]) {
-    warningsCache[resourceName][failedItemName][`__${message}`][fileName] = {
-      message: message.slice(0, message.indexOf(' ')).toUpperCase() + message.slice(message.indexOf(' '), message.length),
+  if (!warningsCache[resourceName][failedItemName][`__${message}`][`${fileName}__${failedItemValue}`]) {
+    warningsCache[resourceName][failedItemName][`__${message}`][`${fileName}__${failedItemValue}`] = {
+      message: !message.startsWith('The')
+        ? message.slice(0, message.indexOf(' ')).toUpperCase() + message.slice(message.indexOf(' '), message.length)
+        : message,
       occurrences: 1
     };
   } else {
-    warningsCache[resourceName][failedItemName][`__${message}`][fileName].occurrences++;
+    warningsCache[resourceName][failedItemName][`__${message}`][`${fileName}__${failedItemValue}`].occurrences++;
   }
   stats.totalWarnings++;
 };

--- a/test/schema/payload-samples.js
+++ b/test/schema/payload-samples.js
@@ -134,6 +134,21 @@ const stringListValidPayload = {
   ]
 };
 
+const specialEnumFieldsValidPayload = {
+  '@reso.context': 'urn:reso:metadata:1.7:resource:property',
+  value: [
+    {
+      Country: 'CA',
+      StateOrProvince: 'ON',
+      City: 'SampleCityEnumValue',
+      PostalCode: 'K2G 1Y9',
+      StreetName: 'Starwood Rd',
+      StreetNumber: '39',
+      MLSAreaMinor: 'TestEnumValuer'
+    }
+  ]
+};
+
 const stringListInvalidPayload = {
   '@reso.context': 'urn:reso:metadata:1.7:resource:property',
   value: [
@@ -184,5 +199,6 @@ module.exports = {
   stringListValidPayload,
   stringListInvalidPayload,
   additionalPropertyPayload,
-  integerOverflowPayload
+  integerOverflowPayload,
+  specialEnumFieldsValidPayload
 };


### PR DESCRIPTION
closes #119

The following file needs to be in the root directory.

#### `schema-validation-settings.json`
```json
{
  "2.0": {
    "Property": {
      "MLSAreaMinor": {
        "ignoreEnumerations": true
      },
      "MLSAreaMajor": {
        "ignoreEnumerations": true
      },
      "MiddleOrJuniorSchoolDistrict": {
        "ignoreEnumerations": true
      },
      "ElementarySchool": {
        "ignoreEnumerations": true
      },
      "HighSchoolDistrict": {
        "ignoreEnumerations": true
      },
      "HighSchool": {
        "ignoreEnumerations": true
      },
      "ElementarySchoolDistrict": {
        "ignoreEnumerations": true
      },
      "MiddleOrJuniorSchool": {
        "ignoreEnumerations": true
      }
    },
    "Media": {
      "ImageSizeDescription": {
        "ignoreEnumerations": true
      }
    }
  }
}

```