### PR TITLE
#117: Change How Service Matching Works

### DIFF
--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -120,23 +120,19 @@ Results will be outputted in a directory called `results`.
 
 In order to use the Variations Service, the Data Dictionary 2.0 tests will need an environment variable with a token. 
 
-This can either be passed as an environment variable: 
+The required parameters can be passed into the container using an environment variable file as follows:
 
 ```
-$ docker run -v ./results:/results -v ./config.json:/config.json -it -e <provider token> reso-certification-utils runDDTests -v 2.0 -p /config.json -l 200 -a 
+$ docker run -v ./results:/results -v ./config.json:/config.json -it --env-file .env reso-certification-utils runDDTests -p /config.json -l 200 -a 
 ```
 
-Or you can use an environment file (preferred): 
+See [`sample.env`](../sample.env) for a sample `.env` file. 
 
-```
-$ docker run -v ./results:/results -v ./config.json:/config.json -it --env-file .env reso-certification-utils runDDTests -v 2.0 -p /config.json -l 200 -a 
-```
+In this case, you will need additional information to use the Variations Service. Please contact [dev@reso.org](mailto:dev@reso.org) for more information. 
 
-Where `.env` file would be a file in the current directory containing a variable called `PROVIDER_TOKEN` with a value. See [`sample.env`](../sample.env) for more information.
+If the auth info isn't present, only machine-matching will be used. This is still enough to get started with DD 2.0 testing.
 
-To obtain a provider token, contact [dev@reso.org](mailto:dev@reso.org).
-
-If no provider token is specified, then only machine-based matching techniques will be used.
+You can also pass the environment variables in the file directly to the container with the `-e` flag, but using a file is preferred since it avoids sensitive information being exposed in the command history.
 
 
 ## Other Tasks

--- a/lib/certification/index.js
+++ b/lib/certification/index.js
@@ -473,13 +473,13 @@ const getDataDictionaryTestSteps = ({
       async () =>
         await replicate({
           ...defaultReplicationSettings,
-          top: DEFAULT_PAGE_SIZE /* TODO: remove for live testing since odata.maxpagesize is used */,
+          maxPageSize: DEFAULT_PAGE_SIZE,
           strategy: REPLICATION_STRATEGIES.NEXT_LINK
         }),
       async () =>
         await replicate({
           ...defaultReplicationSettings,
-          top: DEFAULT_PAGE_SIZE /* TODO: remove for live testing since odata.maxpagesize is used */,
+          maxPageSize: DEFAULT_PAGE_SIZE,
           strategy: REPLICATION_STRATEGIES.NEXT_LINK,
           filter: `ModificationTimestamp ge ${new Date(new Date().getFullYear() - DEFAULT_YEARS_BACK, null).toISOString()}`,
           orderby: 'ModificationTimestamp asc'

--- a/lib/replication/README.md
+++ b/lib/replication/README.md
@@ -6,28 +6,30 @@ Use the following command to view help info:
 
 ```
 $ reso-certification-utils replicate --help
-Usage: reso-certification-utils replicate [options]
+Usage: RESO Certification Utils replicate [options]
 
-Replicates data from a given resource with expansions.
+Replicates data from a given resource with expansions
 
 Options:
   -s, --strategy <string>                  One of TopAndSkip, TimestampAsc, TimestampDesc, or NextLink
   -u, --serviceRootUri <string>            OData service root URI (no resource name or query)
   -b, --bearerToken <string>               Bearer token to use for authorization
-  -c, --clientId <string>                  OAuth2 client_id parameter, use this OR bearerToken
-  -i, --clientSecret <string>              OAuth2 client_secret parameter, use this OR bearerToken
+  -i, --clientId <string>                  OAuth2 client_id parameter, use this OR bearerToken
+  -c, --clientSecret <string>              OAuth2 client_secret parameter, use this OR bearerToken
   -k, --tokenUri <string>                  OAuth2 token_uri parameter, use this OR bearerToken
   -e, --scope <string>                     Optional OAuth2 scopes for client credentials
-  -m, --pathToMetadataReportJson <string>  Path to metadata report JSON
+  -p, --pathToMetadataReportJson <string>  Path to metadata report JSON
   -r, --resourceName <string>              Resource name to replicate data from
   -x, --expansions <items>                 Comma-separated list of items to expand during the query process, e.g. Media,OpenHouse
   -f, --filter <string>                    OData $filter expression
   -t, --top <number>                       Optional parameter to use for OData $top
-  -p, --maxPageSize <number>               Optional parameter for the odata.maxpagesize header
+  -m, --maxPageSize <number>               Optional parameter for the odata.maxpagesize header (default: 100)
   -o, --outputPath <string>                Name of directory for results
   -l, --limit <number>                     Limit total number of records at client level
   -v, --version <string>                   Data Dictionary version to use (default: "2.0")
-  -j, --jsonSchemaValidation <boolean>     Sets whether to use JSON schema validation (default: false)
+  -j, --jsonSchemaValidation               Use JSON schema validation
+  -N, --originatingSystemName <string>     Used when additional filters are needed for OriginatingSystemName
+  -I, --originatingSystemId <string>       Used when additional filters are needed for OriginatingSystemID
   -S, --strictMode <boolean>               Fail immediately on schema validation errors if strict mode is true (default: true)
   -h, --help                               display help for command
 ```
@@ -61,6 +63,8 @@ RESO uses the `replicate` option for Data Dictionary testing, which consists of 
 * **Data Validation** - All sampled data are validated against JSON Schema generated from their metadata
 
 
+For more information about RESO Certification, see the [README](../certification/README.md).
+
 The `replicate` utility performs the latter two of the above steps. 
 
 ## Replicate Data from a RESO Server
@@ -68,13 +72,13 @@ The `replicate` utility performs the latter two of the above steps.
 To test replication using DD 2.0 and `NextLink` behavior, use the following command:
 
 ```
-$ reso-certification-utils replicate -s NextLink -u https://yourapi.com/serviceRoot -c <clientId> -i <clientSecret> -k <tokenUri> -e api -l 100000 -m <your-metadata-report.json> -t 100 -f "OriginatingSystemName eq '<your originating system name>'" -v 2.0
+$ reso-certification-utils replicate -s NextLink -u https://yourapi.com/serviceRoot -c <clientId> -i <clientSecret> -k <tokenUri> -e api -l 100000 -p <your-metadata-report.json> -t 100 -f "OriginatingSystemName eq '<your originating system name>'" -v 2.0
 ```
 
 In DD 1.7, ModificationTimestamp queries were used for testing instead. For example:
 
 ```
-$ reso-certification-utils replicate -s TimestampDesc -u https://yourapi.com/serviceRoot -c <clientId> -i <clientSecret> -k <tokenUri> -e api -l 100000 -m <your-metadata-report.json> -t 100 -f "OriginatingSystemName eq '<your originating system name>'" -v 1.7
+$ reso-certification-utils replicate -s TimestampDesc -u https://yourapi.com/serviceRoot -c <clientId> -i <clientSecret> -k <tokenUri> -e api -l 100000 -p <your-metadata-report.json> -t 100 -f "OriginatingSystemName eq '<your originating system name>'" -v 1.7
 ```
 
 The examples above show the use of the OriginatingSystemName filter. 
@@ -85,7 +89,7 @@ The also assume that the user will have access to the `metadata-report.json` or 
 Once replication is working correctly using the commands above, the next step is to add schema validation. 
 
 ```
-$ reso-certification-utils replicate -s TimestampDesc -u https://yourapi.com/serviceRoot -c <clientId> -i <clientSecret> -k <tokenUri> -e api -l 100000 -m <your-metadata-report.json> -t 100 -f "OriginatingSystemName eq '<your originating system name>'" -v 1.7 -j true -S true
+$ reso-certification-utils replicate -s TimestampDesc -u https://yourapi.com/serviceRoot -c <clientId> -i <clientSecret> -k <tokenUri> -e api -l 100000 -p <your-metadata-report.json> -t 100 -f "OriginatingSystemName eq '<your originating system name>'" -v 1.7 -j true
 ```
 
 In this case, `-j` tells the program to use JSON Schema Validation an `-S` sets strict mode, which will exit on first error. Since the number of JSON Schema validation errors can be potentially large, strict mode is enabled by default.

--- a/lib/replication/index.js
+++ b/lib/replication/index.js
@@ -179,10 +179,7 @@ const replicate = async ({
               const { error } = otherIteratorInfo;
               // some errors, like HTTP 429, might be able to be handled
               await handleError({ error, rateLimitedWaitTimeMinutes });
-            }
-
-            //process results
-            if (hasResults) {
+            } else if (hasResults) {
               if (jsonSchemaValidation) {
                 schemaValidationResults =
                   validate({

--- a/lib/replication/replication-iterator.js
+++ b/lib/replication/replication-iterator.js
@@ -20,7 +20,8 @@ const ODATA_VALUE_PROPERTY_NAME = 'value',
 // See: https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_HeaderPrefer
 // The value of the Prefer header is a comma-separated list of preferences.
 const ODATA_PREFER_HEADER_NAME = 'Prefer',
-  ODATA_MAX_PAGE_SIZE_HEADER_NAME = 'odata.maxpagesize';
+  ODATA_MAX_PAGE_SIZE_HEADER_NAME = 'odata.maxpagesize',
+  ODATA_MAX_PAGE_SIZE_DEFAULT = 1000;
 
 // See: https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358888
 // The value of the Preference-Applied header is a comma-separated list of preferences applied in the response.
@@ -61,8 +62,8 @@ async function* replicationIterator({
     lastIsoTimestamp = null,
     nextLink = null;
 
-  if (strategy === REPLICATION_STRATEGIES.NEXT_LINK && !!maxPageSize) {
-    headers[ODATA_PREFER_HEADER_NAME] = `${ODATA_MAX_PAGE_SIZE_HEADER_NAME}=${maxPageSize}`;
+  if (strategy === REPLICATION_STRATEGIES.NEXT_LINK) {
+    headers[ODATA_PREFER_HEADER_NAME] = `${ODATA_MAX_PAGE_SIZE_HEADER_NAME}=${maxPageSize ?? ODATA_MAX_PAGE_SIZE_DEFAULT}`;
   }
 
   // wait once if specified

--- a/lib/schema/README.md
+++ b/lib/schema/README.md
@@ -5,9 +5,9 @@
 ```
 $ reso-certification-utils schema --help
 
-Usage: reso-certification-utils schema [options]
+Usage: RESO Certification Utils schema [options]
 
-Generate a schema from a given metadata report
+Generate a schema or validate a payload against a schema
 
 Options:
   -G, --generate               Generate a schema for payload validation
@@ -15,7 +15,7 @@ Options:
   -m, --metadataPath <string>  Path to the metadata report JSON file
   -o, --outputPath <string>    Path tho the directory to store the generated schema. Defaults to "./"
   -a, --additionalProperties   Pass this flag to allow additional properties in the schema. False by default
-  -v, --version <string>       The Data Dictionary version of the metadata report
+  -v, --version <string>       The DD version of the metadata report
   -p, --payloadPath <string>   Path to the payload file OR directory/zip containing files that need to be validated
   -r, --resourceName <string>  Resource name to validate against. Required if --version is passed when validating.
   -h, --help                   display help for command

--- a/lib/variations/index.js
+++ b/lib/variations/index.js
@@ -30,13 +30,8 @@ const MATCHING_STRATEGIES = Object.freeze({
   SUBSTRING: 'Substring',
   EDIT_DISTANCE: 'Edit Distance',
   ADMIN_REVIEW: 'Admin Review',
-  EXTERNAL_SUGGESTION: 'Suggestion',
-  IGNORED: 'Ignored'
-});
-
-const MATCHED_ON = Object.freeze({
-  LOOKUP_VALUE: 'lookupValue',
-  LEGACY_ODATA_VALUE: 'legacyODataValue'
+  FAST_TRACK: 'Fast Track',
+  EXTERNAL_SUGGESTION: 'Suggestion'
 });
 
 const checkRequiredCredentials = () => {
@@ -205,7 +200,7 @@ const getMetadataInfo = ({ numResources = 0, numFields = 0, numLookups = 0, numE
 };
 
 /**
- *
+ * Gets the DD Wiki URL for the given Data Dictionary element
  * @param {*} options must have a standardMetadataMap and the resource or field name and lookup value or odata value
  * @returns DD Wiki URL or null if it wasn't found
  */
@@ -224,6 +219,21 @@ const getDDWikiUrl = ({ standardMetadataMap, resourceName, fieldName, lookupValu
     return getReferenceMetadata()?.resources?.find(item => item?.resourceName === resourceName)?.wikiPageURL ?? null;
   } else {
     return null;
+  }
+};
+
+/**
+ * Determines which kind of matching strategy was used for the given suggestion data
+ * @param {*} suggestionData contains various flags from a given suggestion
+ * @returns the appropriate matching strategy
+ */
+const classifySuggestionStrategy = ({ isAdminReview = false, isFastTrack = false } = {}) => {
+  if (isAdminReview) {
+    return MATCHING_STRATEGIES.ADMIN_REVIEW;
+  } else if (isFastTrack) {
+    return MATCHING_STRATEGIES.FAST_TRACK;
+  } else {
+    return MATCHING_STRATEGIES.EXTERNAL_SUGGESTION;
   }
 };
 
@@ -293,99 +303,94 @@ const computeVariations = async ({
     // Process each resource in the metadata
     Object.keys(metadataReportMap).forEach(resourceName => {
       const isStandardResource = !!standardMetadataMap?.[resourceName] ?? false;
-      const { isIgnored: ignoreResourceMapping = false, suggestions: resourceSuggestions = [] } = suggestionsMap?.[resourceName] ?? {};
+      const { ignored: ignoreResourceMapping = false, suggestions: resourceSuggestions = [] } = suggestionsMap?.[resourceName] ?? {};
 
-      if (!isStandardResource) {
-        if (!ignoreResourceMapping) {
-          if (resourceSuggestions?.length) {
-            //check for human-based suggestions first
-            POSSIBLE_VARIATIONS.resources.push(
-              ...(resourceSuggestions.flatMap(({ suggestedResourceName, ...suggestion }) => {
-                if (!metadataReportMap?.[suggestedResourceName]) {
-                  return [
-                    {
-                      resourceName,
-                      suggestedResourceName,
-                      strategy: MATCHING_STRATEGIES.SUGGESTION,
-                      ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName: suggestedResourceName }),
-                      ...suggestion
-                    }
-                  ];
-                } else {
-                  return [];
+      if (!ignoreResourceMapping) {
+        if (resourceSuggestions?.length) {
+          //check for human-based suggestions first
+          POSSIBLE_VARIATIONS.resources.push(
+            ...(resourceSuggestions.flatMap(({ suggestedResourceName, isAdminReview, isFastTrack, ...suggestion }) => {
+              if (!metadataReportMap?.[suggestedResourceName]) {
+                return [
+                  {
+                    resourceName,
+                    suggestedResourceName,
+                    strategy: classifySuggestionStrategy({ isAdminReview, isFastTrack }),
+                    ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName: suggestedResourceName }),
+                    ...suggestion
+                  }
+                ];
+              } else {
+                return [];
+              }
+            }) ?? [])
+          );
+        } else if (!isStandardResource) {
+          //use machine techniques
+          Object.keys(standardMetadataMap).forEach(standardResourceName => {
+            const normalizedStandardResourceName = normalizeDataElementName(standardResourceName),
+              normalizedResourceName = normalizeDataElementName(resourceName);
+
+            const hasStandardResource = !!metadataReportMap?.[standardResourceName];
+
+            if (!hasStandardResource) {
+              const isMinMatchingLength = resourceName?.length > MIN_MATCHING_LENGTH;
+              const isExactMatch = !!(resourceName !== standardResourceName && normalizedResourceName === normalizedStandardResourceName);
+
+              const isSubstringMatch = !!(
+                isMinMatchingLength &&
+                ((normalizedStandardResourceName?.length > MIN_MATCHING_LENGTH &&
+                  normalizedResourceName.includes(normalizedStandardResourceName)) ||
+                  (normalizedResourceName?.length > MIN_MATCHING_LENGTH && normalizedStandardResourceName.includes(normalizedResourceName)))
+              );
+
+              if (isExactMatch || isSubstringMatch) {
+                const suggestion = {
+                  resourceName,
+                  suggestedResourceName: standardResourceName,
+                  strategy: MATCHING_STRATEGIES.SUBSTRING,
+                  ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName: standardResourceName })
+                };
+
+                if (isExactMatch) {
+                  suggestion.exactMatch = true;
                 }
-              }) ?? [])
-            );
-          } else {
-            //use machine techniques
-            Object.keys(standardMetadataMap).forEach(standardResourceName => {
-              const normalizedStandardResourceName = normalizeDataElementName(standardResourceName),
-                normalizedResourceName = normalizeDataElementName(resourceName);
 
-              const hasStandardResource = !!metadataReportMap?.[standardResourceName];
+                POSSIBLE_VARIATIONS.resources.push(suggestion);
+              } else if (isMinMatchingLength) {
+                const d = distance(normalizedStandardResourceName, normalizedResourceName),
+                  maxDistance = Math.floor(fuzziness * resourceName?.length);
 
-              if (!hasStandardResource) {
-                const isMinMatchingLength = resourceName?.length > MIN_MATCHING_LENGTH;
-                const isExactMatch = !!(resourceName !== standardResourceName && normalizedResourceName === normalizedStandardResourceName);
-
-                const isSubstringMatch = !!(
-                  isMinMatchingLength &&
-                  ((normalizedStandardResourceName?.length > MIN_MATCHING_LENGTH &&
-                    normalizedResourceName.includes(normalizedStandardResourceName)) ||
-                    (normalizedResourceName?.length > MIN_MATCHING_LENGTH &&
-                      normalizedStandardResourceName.includes(normalizedResourceName)))
-                );
-
-                if (isExactMatch || isSubstringMatch) {
+                if (d <= maxDistance) {
                   const suggestion = {
                     resourceName,
                     suggestedResourceName: standardResourceName,
-                    strategy: MATCHING_STRATEGIES.SUBSTRING,
+                    distance: d,
+                    maxDistance,
+                    strategy: MATCHING_STRATEGIES.EDIT_DISTANCE,
                     ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName: standardResourceName })
                   };
 
-                  if (isExactMatch) {
-                    suggestion.exactMatch = true;
+                  if (d <= CLOSE_MATCH_DISTANCE) {
+                    suggestion.closeMatch = true;
                   }
 
                   POSSIBLE_VARIATIONS.resources.push(suggestion);
-                } else if (isMinMatchingLength) {
-                  const d = distance(normalizedStandardResourceName, normalizedResourceName),
-                    maxDistance = Math.floor(fuzziness * resourceName?.length);
-
-                  if (d <= maxDistance) {
-                    const suggestion = {
-                      resourceName,
-                      suggestedResourceName: standardResourceName,
-                      distance: d,
-                      maxDistance,
-                      strategy: MATCHING_STRATEGIES.EDIT_DISTANCE,
-                      ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName: standardResourceName })
-                    };
-
-                    if (d <= CLOSE_MATCH_DISTANCE) {
-                      suggestion.closeMatch = true;
-                    }
-
-                    POSSIBLE_VARIATIONS.resources.push(suggestion);
-                  }
                 }
               }
-            });
-          }
-        }
-      } else {
-        // Standard Resource - Process each field
-        Object.keys(metadataReportMap?.[resourceName] ?? {}).forEach(fieldName => {
-          const isStandardField = !!standardMetadataMap?.[resourceName]?.[fieldName] ?? false;
-          const { isIgnored: ignoreFieldMapping = false, suggestions: fieldSuggestions = [] } =
-            suggestionsMap?.[resourceName]?.[fieldName] ?? {};
+            }
+          });
+        } else {
+          //found standard resource - check field name variations
+          Object.keys(metadataReportMap?.[resourceName] ?? {}).forEach(fieldName => {
+            const isStandardField = !!standardMetadataMap?.[resourceName]?.[fieldName] ?? false;
+            const { ignored: ignoreFieldMapping = false, suggestions: fieldSuggestions = [] } =
+              suggestionsMap?.[resourceName]?.[fieldName] ?? {};
 
-          if (!isStandardField) {
             if (!ignoreFieldMapping) {
               if (fieldSuggestions?.length) {
-                POSSIBLE_VARIATIONS.fields.push(
-                  ...(fieldSuggestions.flatMap(({ suggestedResourceName, suggestedFieldName, ...suggestion }) => {
+                const suggestions =
+                  fieldSuggestions.flatMap(({ suggestedResourceName, suggestedFieldName, isAdminReview, isFastTrack, ...suggestion }) => {
                     if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]) {
                       return [
                         {
@@ -393,7 +398,7 @@ const computeVariations = async ({
                           fieldName,
                           suggestedResourceName,
                           suggestedFieldName,
-                          strategy: MATCHING_STRATEGIES.SUGGESTION,
+                          strategy: classifySuggestionStrategy({ isAdminReview, isFastTrack }),
                           ddWikiUrl: getDDWikiUrl({
                             standardMetadataMap,
                             resourceName: suggestedResourceName,
@@ -405,9 +410,11 @@ const computeVariations = async ({
                     } else {
                       return [];
                     }
-                  }) ?? [])
-                );
-              } else {
+                  }) ?? [];
+
+                POSSIBLE_VARIATIONS.fields.push(...suggestions);
+              } else if (!isStandardField) {
+                // use machine matching
                 const isExpansion = !!metadataReportMap?.[resourceName]?.[fieldName]?.isExpansion ?? false;
 
                 if (!isExpansion) {
@@ -488,37 +495,39 @@ const computeVariations = async ({
                   // TODO
                   // console.log(`TODO: Expansion found! Resource: '${resourceName}', Field: '${fieldName}'`);
                 }
-              }
-            }
-          } else {
-            //standard field - if lookup field then try and process the nested lookups
-            const { lookupValues = {}, legacyODataValues = {} } = metadataReportMap?.[resourceName]?.[fieldName] || {};
+              } else {
+                // found standard field - if lookup field then try and process the nested lookups
+                const { lookupValues = {}, legacyODataValues = {} } = metadataReportMap?.[resourceName]?.[fieldName] || {};
 
-            const standardLookupValues = standardMetadataMap?.[resourceName]?.[fieldName]?.lookupValues || {};
+                //check lookupValues
+                Object.values(lookupValues ?? {}).forEach(({ lookupValue }) => {
+                  const standardLookupValues = standardMetadataMap?.[resourceName]?.[fieldName]?.lookupValues || {},
+                    isStandardLookupValue = !!standardLookupValues?.[lookupValue] ?? false;
 
-            //check lookupValues
-            Object.values(lookupValues ?? {}).forEach(({ lookupValue }) => {
-              const isStandardLookupValue = !!standardLookupValues?.[lookupValue] ?? false;
-              const { isIgnored: ignoreLookupValueMapping = false, suggestions: lookupValueSuggestions = [] } =
-                suggestionsMap?.[resourceName]?.[fieldName]?.[lookupValue] ?? {};
+                  const { ignored: ignoreLookupValueMapping = false, suggestions: lookupValueSuggestions = [] } =
+                    suggestionsMap?.[resourceName]?.[fieldName]?.[lookupValue] ?? {};
 
-              if (!isStandardLookupValue) {
-                if (!ignoreLookupValueMapping) {
-                  if (lookupValueSuggestions?.length) {
-                    // use human suggestions
-                    POSSIBLE_VARIATIONS.lookupValues.push(
-                      ...(lookupValueSuggestions.flatMap(
-                        ({ suggestedResourceName, suggestedFieldName, suggestedLookupValue, ...suggestion }) => {
-                          if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLookupValue]) {
-                            return [
-                              {
+                  if (!ignoreLookupValueMapping) {
+                    if (lookupValueSuggestions?.length) {
+                      const suggestions =
+                        lookupValueSuggestions.flatMap(
+                          ({
+                            suggestedResourceName,
+                            suggestedFieldName,
+                            suggestedLookupValue,
+                            isAdminReview,
+                            isFastTrack,
+                            ...suggestion
+                          }) => {
+                            if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLookupValue]) {
+                              return [{
                                 resourceName,
                                 fieldName,
                                 lookupValue,
                                 suggestedResourceName,
                                 suggestedFieldName,
                                 suggestedLookupValue,
-                                strategy: MATCHING_STRATEGIES.SUGGESTION,
+                                strategy: classifySuggestionStrategy({ isAdminReview, isFastTrack }),
                                 ddWikiUrl: getDDWikiUrl({
                                   standardMetadataMap,
                                   resourceName: suggestedResourceName,
@@ -526,226 +535,223 @@ const computeVariations = async ({
                                   lookupValue: suggestedLookupValue
                                 }),
                                 ...suggestion
-                              }
-                            ];
-                          } else {
-                            return [];
+                              }];
+                            } else {
+                              return [];
+                            }
                           }
-                        }
-                      ) ?? [])
-                    );
-                  } else {
-                    // use machine techniques
-                    Object.keys(standardLookupValues).forEach(standardLookupValue => {
-                      const normalizedLookupValue = normalizeDataElementName(lookupValue);
-                      const normalizedStandardLookupValue = normalizeDataElementName(standardLookupValue);
+                        ) ?? [];
 
-                      const isMinMatchingLength = lookupValue?.length > MIN_MATCHING_LENGTH;
-                      const isExactMatch = !!(
-                        lookupValue !== standardLookupValue && normalizedLookupValue === normalizedStandardLookupValue
-                      );
-                      const hasStandardLookupValue =
-                        !!metadataReportMap?.[resourceName]?.[fieldName]?.lookupValues?.[standardLookupValue] ?? false;
+                      POSSIBLE_VARIATIONS.lookupValues.push(...suggestions);
+                    } else if (!isStandardLookupValue) {
+                      // use machine matching techniques
+                      Object.keys(standardLookupValues).forEach(standardLookupValue => {
+                        const normalizedLookupValue = normalizeDataElementName(lookupValue);
+                        const normalizedStandardLookupValue = normalizeDataElementName(standardLookupValue);
 
-                      const isSubstringMatch = !!(
-                        isMinMatchingLength &&
-                        ((normalizedStandardLookupValue?.length > MIN_MATCHING_LENGTH &&
-                          normalizedLookupValue.includes(normalizedStandardLookupValue)) ||
-                          (normalizedLookupValue?.length > MIN_MATCHING_LENGTH &&
-                            normalizedStandardLookupValue.includes(normalizedLookupValue)))
-                      );
+                        const isMinMatchingLength = lookupValue?.length > MIN_MATCHING_LENGTH;
+                        const isExactMatch = !!(
+                          lookupValue !== standardLookupValue && normalizedLookupValue === normalizedStandardLookupValue
+                        );
+                        const hasStandardLookupValue =
+                          !!metadataReportMap?.[resourceName]?.[fieldName]?.lookupValues?.[standardLookupValue] ?? false;
 
-                      if (!hasStandardLookupValue) {
-                        //first check case-insensitive substring matches
-                        if (isExactMatch || isSubstringMatch) {
-                          const suggestion = {
-                            resourceName,
-                            fieldName,
-                            lookupValue,
-                            suggestedLookupValue: standardLookupValue,
-                            matchedOn: MATCHED_ON.LOOKUP_VALUE,
-                            strategy: MATCHING_STRATEGIES.SUBSTRING,
-                            ddWikiUrl: getDDWikiUrl({
-                              standardMetadataMap,
-                              resourceName,
-                              fieldName,
-                              lookupValue: standardLookupValue
-                            })
-                          };
+                        const isSubstringMatch = !!(
+                          isMinMatchingLength &&
+                          ((normalizedStandardLookupValue?.length > MIN_MATCHING_LENGTH &&
+                            normalizedLookupValue.includes(normalizedStandardLookupValue)) ||
+                            (normalizedLookupValue?.length > MIN_MATCHING_LENGTH &&
+                              normalizedStandardLookupValue.includes(normalizedLookupValue)))
+                        );
 
-                          if (isExactMatch) {
-                            suggestion.exactMatch = true;
-
-                            // add exact matches at the head of the list
-                            POSSIBLE_VARIATIONS.lookupValues.unshift(suggestion);
-                          } else {
-                            POSSIBLE_VARIATIONS.lookupValues.push(suggestion);
-                          }
-                        } else if (isMinMatchingLength) {
-                          const d = distance(normalizedLookupValue, normalizedStandardLookupValue),
-                            maxDistance = Math.floor(fuzziness * lookupValue?.length);
-
-                          if (!hasStandardLookupValue && d <= maxDistance) {
+                        if (!hasStandardLookupValue) {
+                          //first check case-insensitive substring matches
+                          if (isExactMatch || isSubstringMatch) {
                             const suggestion = {
                               resourceName,
                               fieldName,
                               lookupValue,
-                              distance: d,
-                              maxDistance,
-                              strategy: MATCHING_STRATEGIES.EDIT_DISTANCE
+                              suggestedLookupValue: standardLookupValue,
+                              strategy: MATCHING_STRATEGIES.SUBSTRING,
+                              ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName, fieldName, lookupValue: standardLookupValue })
                             };
 
-                            if (lookupValue !== standardLookupValue) {
-                              suggestion.matchedOn = MATCHED_ON.LOOKUP_VALUE;
-                              suggestion.suggestedLookupValue = standardLookupValue;
-                              suggestion.ddWikiUrl = getDDWikiUrl({
-                                standardMetadataMap,
+                            if (isExactMatch) {
+                              suggestion.exactMatch = true;
+
+                              // add exact matches at the head of the list
+                              POSSIBLE_VARIATIONS.lookupValues.unshift(suggestion);
+                            } else {
+                              POSSIBLE_VARIATIONS.lookupValues.push(suggestion);
+                            }
+                          } else if (isMinMatchingLength) {
+                            const d = distance(normalizedLookupValue, normalizedStandardLookupValue),
+                              maxDistance = Math.floor(fuzziness * lookupValue?.length);
+
+                            if (!hasStandardLookupValue && d <= maxDistance) {
+                              const suggestion = {
                                 resourceName,
                                 fieldName,
-                                lookupValue: standardLookupValue
-                              });
-                            }
+                                lookupValue,
+                                distance: d,
+                                maxDistance,
+                                strategy: MATCHING_STRATEGIES.EDIT_DISTANCE
+                              };
 
-                            if (d <= CLOSE_MATCH_DISTANCE) {
-                              suggestion.closeMatch = true;
-                            }
-
-                            POSSIBLE_VARIATIONS.lookupValues.push(suggestion);
-                          }
-                        }
-                      }
-                    });
-                  }
-                }
-              }
-            });
-
-            const standardLegacyODataValues = standardMetadataMap?.[resourceName]?.[fieldName]?.legacyODataValues || {};
-
-            //check legacyODataValues
-            Object.values(legacyODataValues ?? {}).forEach(({ legacyODataValue }) => {
-              const isStandardLegacyODataValue = standardLegacyODataValues?.[legacyODataValue] ?? false;
-              const { isIgnored: ignoreLegacyODataValueMapping = false, suggestions: legacyODataValueSuggestions = [] } =
-                suggestionsMap?.[resourceName]?.[fieldName]?.[legacyODataValue] ?? {};
-
-              if (!isStandardLegacyODataValue) {
-                if (!ignoreLegacyODataValueMapping) {
-                  if (legacyODataValueSuggestions?.length) {
-                    //use human suggestions
-                    POSSIBLE_VARIATIONS.legacyODataValues.push(
-                      ...(legacyODataValueSuggestions.flatMap(
-                        ({ suggestedResourceName, suggestedFieldName, suggestedLegacyODataValue, ...suggestion }) => {
-                          if (
-                            !metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLegacyODataValue]
-                          ) {
-                            return [
-                              {
-                                resourceName,
-                                fieldName,
-                                legacyODataValue,
-                                suggestedResourceName,
-                                suggestedFieldName,
-                                suggestedLegacyODataValue,
-                                strategy: MATCHING_STRATEGIES.SUGGESTION,
-                                ddWikiUrl: getDDWikiUrl({
+                              if (lookupValue !== standardLookupValue) {
+                                suggestion.suggestedLookupValue = standardLookupValue;
+                                suggestion.ddWikiUrl = getDDWikiUrl({
                                   standardMetadataMap,
-                                  resourceName: suggestedResourceName,
-                                  fieldName: suggestedFieldName,
-                                  legacyODataValue: suggestedLegacyODataValue
-                                }),
-                                ...suggestion
+                                  resourceName,
+                                  fieldName,
+                                  lookupValue: standardLookupValue
+                                });
                               }
-                            ];
-                          } else {
-                            return [];
+
+                              if (d <= CLOSE_MATCH_DISTANCE) {
+                                suggestion.closeMatch = true;
+                              }
+
+                              POSSIBLE_VARIATIONS.lookupValues.push(suggestion);
+                            }
                           }
                         }
-                      ) ?? [])
-                    );
-                  } else {
-                    Object.keys(standardLegacyODataValues).forEach(standardODataLookupValue => {
-                      const normalizedODataValue = normalizeDataElementName(legacyODataValue);
-                      const normalizedStandardODataValue = normalizeDataElementName(standardODataLookupValue);
+                      });
+                    }
+                  }
+                });
 
-                      const isMinMatchingLength = legacyODataValue?.length > MIN_MATCHING_LENGTH;
-                      const isExactMatch = !!(
-                        normalizedODataValue === normalizedStandardODataValue && legacyODataValue !== standardODataLookupValue
-                      );
+                //check legacyODataValues
+                Object.values(legacyODataValues ?? {}).forEach(({ legacyODataValue }) => {
+                  const standardLegacyODataValues = standardMetadataMap?.[resourceName]?.[fieldName]?.legacyODataValues || {},
+                    isStandardLegacyODataValue = standardLegacyODataValues?.[legacyODataValue] ?? false;
 
-                      const hasStandardLegacyODataValue =
-                        !!metadataReportMap?.[resourceName]?.[fieldName]?.legacyODataValues?.[standardODataLookupValue] ?? false;
+                  const { ignored: ignoreLegacyODataValueMapping = false, suggestions: legacyODataValueSuggestions = [] } =
+                    suggestionsMap?.[resourceName]?.[fieldName]?.[legacyODataValue] ?? {};
 
-                      const isSubstringMatch = !!(
-                        isMinMatchingLength &&
-                        ((normalizedStandardODataValue?.length > MIN_MATCHING_LENGTH &&
-                          normalizedODataValue.includes(normalizedStandardODataValue)) ||
-                          (normalizedODataValue?.length > MIN_MATCHING_LENGTH &&
-                            normalizedStandardODataValue.includes(normalizedODataValue)))
-                      );
-
-                      if (!hasStandardLegacyODataValue) {
-                        if (isExactMatch || isSubstringMatch) {
-                          const suggestion = {
-                            resourceName,
-                            fieldName,
-                            legacyODataValue,
-                            suggestedLegacyODataValue: standardODataLookupValue,
-                            matchedOn: MATCHED_ON.LEGACY_ODATA_VALUE,
-                            strategy: MATCHING_STRATEGIES.SUBSTRING,
-                            ddWikiUrl: getDDWikiUrl({
-                              standardMetadataMap,
-                              resourceName,
-                              fieldName,
-                              legacyODataValue: standardODataLookupValue
-                            })
-                          };
-
-                          if (isExactMatch) {
-                            suggestion.exactMatch = true;
-                            POSSIBLE_VARIATIONS.legacyODataValues.unshift(suggestion);
-                          } else {
-                            POSSIBLE_VARIATIONS.legacyODataValues.push(suggestion);
+                  if (!ignoreLegacyODataValueMapping) {
+                    if (legacyODataValueSuggestions?.length) {
+                      POSSIBLE_VARIATIONS.legacyODataValues.push(
+                        ...(legacyODataValueSuggestions.flatMap(
+                          ({
+                            suggestedResourceName,
+                            suggestedFieldName,
+                            suggestedLegacyODataValue,
+                            isAdminReview,
+                            isFastTrack,
+                            ...suggestion
+                          }) => {
+                            if (
+                              !metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLegacyODataValue]
+                            ) {
+                              return [
+                                {
+                                  resourceName,
+                                  fieldName,
+                                  legacyODataValue,
+                                  suggestedResourceName,
+                                  suggestedFieldName,
+                                  suggestedLegacyODataValue,
+                                  strategy: classifySuggestionStrategy({ isAdminReview, isFastTrack }),
+                                  ddWikiUrl: getDDWikiUrl({
+                                    standardMetadataMap,
+                                    resourceName: suggestedResourceName,
+                                    fieldName: suggestedFieldName,
+                                    lookupValue: suggestedLegacyODataValue
+                                  }),
+                                  ...suggestion
+                                }
+                              ];
+                            } else {
+                              return [];
+                            }
                           }
-                        } else if (isMinMatchingLength) {
-                          const d = distance(legacyODataValue, standardODataLookupValue),
-                            maxDistance = Math.round(fuzziness * legacyODataValue?.length);
+                        ) ?? [])
+                      );
+                    } else if (!isStandardLegacyODataValue) {
+                      // use machine matching techniques
+                      Object.keys(standardLegacyODataValues).forEach(standardODataLookupValue => {
+                        const normalizedODataValue = normalizeDataElementName(legacyODataValue);
+                        const normalizedStandardODataValue = normalizeDataElementName(standardODataLookupValue);
 
-                          if (d <= maxDistance) {
+                        const isMinMatchingLength = legacyODataValue?.length > MIN_MATCHING_LENGTH;
+                        const isExactMatch = !!(
+                          normalizedODataValue === normalizedStandardODataValue && legacyODataValue !== standardODataLookupValue
+                        );
+
+                        const hasStandardLegacyODataValue =
+                          !!metadataReportMap?.[resourceName]?.[fieldName]?.legacyODataValues?.[standardODataLookupValue] ?? false;
+
+                        const isSubstringMatch = !!(
+                          isMinMatchingLength &&
+                          ((normalizedStandardODataValue?.length > MIN_MATCHING_LENGTH &&
+                            normalizedODataValue.includes(normalizedStandardODataValue)) ||
+                            (normalizedODataValue?.length > MIN_MATCHING_LENGTH &&
+                              normalizedStandardODataValue.includes(normalizedODataValue)))
+                        );
+
+                        if (!hasStandardLegacyODataValue) {
+                          if (isExactMatch || isSubstringMatch) {
                             const suggestion = {
                               resourceName,
                               fieldName,
                               legacyODataValue,
-                              distance: d,
-                              maxDistance,
-                              strategy: MATCHING_STRATEGIES.EDIT_DISTANCE
-                            };
-
-                            if (legacyODataValue !== standardODataLookupValue) {
-                              suggestion.matchedOn = MATCHED_ON.LEGACY_ODATA_VALUE;
-                              suggestion.suggestedLegacyODataValue = standardODataLookupValue;
-                              suggestion.ddWikiUrl = getDDWikiUrl({
+                              suggestedLegacyODataValue: standardODataLookupValue,
+                              strategy: MATCHING_STRATEGIES.SUBSTRING,
+                              ddWikiUrl: getDDWikiUrl({
                                 standardMetadataMap,
                                 resourceName,
                                 fieldName,
                                 legacyODataValue: standardODataLookupValue
-                              });
-                            }
+                              })
+                            };
 
-                            if (d <= CLOSE_MATCH_DISTANCE) {
-                              suggestion.closeMatch = true;
+                            if (isExactMatch) {
+                              suggestion.exactMatch = true;
+                              POSSIBLE_VARIATIONS.legacyODataValues.unshift(suggestion);
+                            } else {
+                              POSSIBLE_VARIATIONS.legacyODataValues.push(suggestion);
                             }
+                          } else if (isMinMatchingLength) {
+                            const d = distance(legacyODataValue, standardODataLookupValue),
+                              maxDistance = Math.round(fuzziness * legacyODataValue?.length);
 
-                            POSSIBLE_VARIATIONS.legacyODataValues.push(suggestion);
+                            if (d <= maxDistance) {
+                              const suggestion = {
+                                resourceName,
+                                fieldName,
+                                legacyODataValue,
+                                distance: d,
+                                maxDistance,
+                                strategy: MATCHING_STRATEGIES.EDIT_DISTANCE
+                              };
+
+                              if (legacyODataValue !== standardODataLookupValue) {
+                                suggestion.suggestedLegacyODataValue = standardODataLookupValue;
+                                suggestion.ddWikiUrl = getDDWikiUrl({
+                                  standardMetadataMap,
+                                  resourceName,
+                                  fieldName,
+                                  legacyODataValue: standardODataLookupValue
+                                });
+                              }
+
+                              if (d <= CLOSE_MATCH_DISTANCE) {
+                                suggestion.closeMatch = true;
+                              }
+
+                              POSSIBLE_VARIATIONS.legacyODataValues.push(suggestion);
+                            }
                           }
                         }
-                      }
-                    });
+                      });
+                    }
                   }
-                }
+                });
               }
-            });
-          }
-        });
+            }
+          });
+        }
       }
     });
 

--- a/lib/variations/index.js
+++ b/lib/variations/index.js
@@ -298,8 +298,6 @@ const computeVariations = async ({
       startTime = new Date();
     }
 
-    //console.log(`Suggestions Map:\n${JSON.stringify(suggestionsMap, null, 2)}`);
-
     // Process each resource in the metadata
     Object.keys(metadataReportMap).forEach(resourceName => {
       const isStandardResource = !!standardMetadataMap?.[resourceName] ?? false;
@@ -389,30 +387,27 @@ const computeVariations = async ({
 
             if (!ignoreFieldMapping) {
               if (fieldSuggestions?.length) {
-                const suggestions =
-                  fieldSuggestions.flatMap(({ suggestedResourceName, suggestedFieldName, isAdminReview, isFastTrack, ...suggestion }) => {
-                    if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]) {
-                      return [
-                        {
-                          resourceName,
-                          fieldName,
-                          suggestedResourceName,
-                          suggestedFieldName,
-                          strategy: classifySuggestionStrategy({ isAdminReview, isFastTrack }),
-                          ddWikiUrl: getDDWikiUrl({
-                            standardMetadataMap,
-                            resourceName: suggestedResourceName,
-                            fieldName: suggestedFieldName
-                          }),
-                          ...suggestion
-                        }
-                      ];
-                    } else {
-                      return [];
-                    }
-                  }) ?? [];
-
-                POSSIBLE_VARIATIONS.fields.push(...suggestions);
+                POSSIBLE_VARIATIONS.fields.push(...(fieldSuggestions.flatMap(({ suggestedResourceName, suggestedFieldName, isAdminReview, isFastTrack, ...suggestion }) => {
+                  if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]) {
+                    return [
+                      {
+                        resourceName,
+                        fieldName,
+                        suggestedResourceName,
+                        suggestedFieldName,
+                        strategy: classifySuggestionStrategy({ isAdminReview, isFastTrack }),
+                        ddWikiUrl: getDDWikiUrl({
+                          standardMetadataMap,
+                          resourceName: suggestedResourceName,
+                          fieldName: suggestedFieldName
+                        }),
+                        ...suggestion
+                      }
+                    ];
+                  } else {
+                    return [];
+                  }
+                }) ?? []));
               } else if (!isStandardField) {
                 // use machine matching
                 const isExpansion = !!metadataReportMap?.[resourceName]?.[fieldName]?.isExpansion ?? false;
@@ -509,40 +504,37 @@ const computeVariations = async ({
 
                   if (!ignoreLookupValueMapping) {
                     if (lookupValueSuggestions?.length) {
-                      const suggestions =
-                        lookupValueSuggestions.flatMap(
-                          ({
-                            suggestedResourceName,
-                            suggestedFieldName,
-                            suggestedLookupValue,
-                            isAdminReview,
-                            isFastTrack,
-                            ...suggestion
-                          }) => {
-                            if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLookupValue]) {
-                              return [{
-                                resourceName,
-                                fieldName,
-                                lookupValue,
-                                suggestedResourceName,
-                                suggestedFieldName,
-                                suggestedLookupValue,
-                                strategy: classifySuggestionStrategy({ isAdminReview, isFastTrack }),
-                                ddWikiUrl: getDDWikiUrl({
-                                  standardMetadataMap,
-                                  resourceName: suggestedResourceName,
-                                  fieldName: suggestedFieldName,
-                                  lookupValue: suggestedLookupValue
-                                }),
-                                ...suggestion
-                              }];
-                            } else {
-                              return [];
-                            }
+                      POSSIBLE_VARIATIONS.lookupValues.push(...(lookupValueSuggestions.flatMap(
+                        ({
+                          suggestedResourceName,
+                          suggestedFieldName,
+                          suggestedLookupValue,
+                          isAdminReview,
+                          isFastTrack,
+                          ...suggestion
+                        }) => {
+                          if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLookupValue]) {
+                            return [{
+                              resourceName,
+                              fieldName,
+                              lookupValue,
+                              suggestedResourceName,
+                              suggestedFieldName,
+                              suggestedLookupValue,
+                              strategy: classifySuggestionStrategy({ isAdminReview, isFastTrack }),
+                              ddWikiUrl: getDDWikiUrl({
+                                standardMetadataMap,
+                                resourceName: suggestedResourceName,
+                                fieldName: suggestedFieldName,
+                                lookupValue: suggestedLookupValue
+                              }),
+                              ...suggestion
+                            }];
+                          } else {
+                            return [];
                           }
-                        ) ?? [];
-
-                      POSSIBLE_VARIATIONS.lookupValues.push(...suggestions);
+                        }
+                      ) ?? []));
                     } else if (!isStandardLookupValue) {
                       // use machine matching techniques
                       Object.keys(standardLookupValues).forEach(standardLookupValue => {

--- a/lib/variations/index.js
+++ b/lib/variations/index.js
@@ -29,7 +29,8 @@ const DEFAULT_FUZZINESS = 0.25,
 const MATCHING_STRATEGIES = Object.freeze({
   SUBSTRING: 'Substring',
   EDIT_DISTANCE: 'Edit Distance',
-  SUGGESTION: 'Suggestion',
+  ADMIN_REVIEW: 'Admin Review',
+  EXTERNAL_SUGGESTION: 'Suggestion',
   IGNORED: 'Ignored'
 });
 
@@ -204,6 +205,29 @@ const getMetadataInfo = ({ numResources = 0, numFields = 0, numLookups = 0, numE
 };
 
 /**
+ *
+ * @param {*} options must have a standardMetadataMap and the resource or field name and lookup value or odata value
+ * @returns DD Wiki URL or null if it wasn't found
+ */
+const getDDWikiUrl = ({ standardMetadataMap, resourceName, fieldName, lookupValue, oDataLookupValue }) => {
+  if (!standardMetadataMap || !Object.values(standardMetadataMap)?.length) {
+    return null;
+  }
+
+  if (resourceName && fieldName && lookupValue) {
+    return standardMetadataMap?.[resourceName]?.[fieldName]?.lookupValues?.[lookupValue]?.ddWikiUrl ?? null;
+  } else if (resourceName && fieldName && oDataLookupValue) {
+    return standardMetadataMap?.[resourceName]?.[fieldName]?.legacyODataValues?.[oDataLookupValue]?.ddWikiUrl ?? null;
+  } else if (resourceName && fieldName) {
+    return standardMetadataMap?.[resourceName]?.[fieldName]?.ddWikiUrl ?? null;
+  } else if (resourceName) {
+    return getReferenceMetadata()?.resources?.find(item => item?.resourceName === resourceName)?.wikiPageURL ?? null;
+  } else {
+    return null;
+  }
+};
+
+/**
  * Calculates variations based on algorithmic and human-provided mappings
  * @param {Object} params metadata report params such as fuzziness and version
  * @returns Data Dictionary variations report JSON
@@ -245,30 +269,6 @@ const computeVariations = async ({
 
     const { metadataMap: standardMetadataMap = {}, stats: referenceMetadataStats = {} } = buildMetadataMap(referenceMetadata);
 
-    const getDDWikiUrlForResourceName = resourceName => {
-      if (!resourceName) return null;
-
-      return getReferenceMetadata()?.resources?.find(item => item?.resourceName === resourceName)?.wikiPageURL ?? null;
-    };
-
-    const getDDWikiUrlForFieldName = (resourceName, fieldName) => {
-      if (!(resourceName && fieldName)) return null;
-
-      return standardMetadataMap?.[resourceName]?.[fieldName]?.ddWikiUrl ?? null;
-    };
-
-    const getDDWikiUrlForLookupValue = (resourceName, fieldName, lookupValue) => {
-      if (!(resourceName && fieldName && lookupValue)) return null;
-
-      return standardMetadataMap?.[resourceName]?.[fieldName]?.lookupValues?.[lookupValue]?.ddWikiUrl ?? null;
-    };
-
-    const getDDWikiUrlForODataLookupValue = (resourceName, fieldName, oDataLookupValue) => {
-      if (!(resourceName && fieldName && oDataLookupValue)) return null;
-
-      return standardMetadataMap?.[resourceName]?.[fieldName]?.legacyODataValues?.[oDataLookupValue]?.ddWikiUrl ?? null;
-    };
-
     if (fromCli) {
       console.log('Metadata info:', getMetadataInfo(referenceMetadataStats));
       console.log(`Time taken: ${calculateElapsedTimeString(startTime, true)}`);
@@ -288,427 +288,459 @@ const computeVariations = async ({
       startTime = new Date();
     }
 
-    // For each resource...
+    //console.log(`Suggestions Map:\n${JSON.stringify(suggestionsMap, null, 2)}`);
+
+    // Process each resource in the metadata
     Object.keys(metadataReportMap).forEach(resourceName => {
       const isStandardResource = !!standardMetadataMap?.[resourceName] ?? false;
+      const { isIgnored: ignoreResourceMapping = false, suggestions: resourceSuggestions = [] } = suggestionsMap?.[resourceName] ?? {};
 
-      //check for resource variations if the resource name doesn't match the reference metadata exactly
       if (!isStandardResource) {
-        const resourceNameSuggestions = suggestionsMap?.[resourceName]?.suggestions ?? [];
-
-        if (resourceNameSuggestions?.length) {
-          // for each suggestion, only use it if the suggested item isn't already there...
-          const remainingSuggestions =
-            resourceNameSuggestions.flatMap(({ suggestedResourceName, ...suggestion }) => {
-              if (!metadataReportMap?.[suggestedResourceName]) {
-                return [
-                  {
-                    resourceName,
-                    suggestedResourceName,
-                    strategy: MATCHING_STRATEGIES.SUGGESTION,
-                    ddWikiUrl: getDDWikiUrlForResourceName(suggestedResourceName),
-                    ...suggestion
-                  }
-                ];
-              } else {
-                return [];
-              }
-            }) ?? [];
-
-          if (remainingSuggestions?.length) {
-            POSSIBLE_VARIATIONS.resources.push(...remainingSuggestions);
-          }
-        } else {
-          Object.keys(standardMetadataMap).forEach(standardResourceName => {
-            const normalizedStandardResourceName = normalizeDataElementName(standardResourceName),
-              normalizedResourceName = normalizeDataElementName(resourceName);
-
-            const hasStandardResource = !!metadataReportMap?.[standardResourceName];
-
-            if (!hasStandardResource) {
-              const isMinMatchingLength = resourceName?.length > MIN_MATCHING_LENGTH;
-              const isExactMatch = !!(resourceName !== standardResourceName && normalizedResourceName === normalizedStandardResourceName);
-
-              const isSubstringMatch = !!(
-                isMinMatchingLength &&
-                ((normalizedStandardResourceName?.length > MIN_MATCHING_LENGTH &&
-                  normalizedResourceName.includes(normalizedStandardResourceName)) ||
-                  (normalizedResourceName?.length > MIN_MATCHING_LENGTH && normalizedStandardResourceName.includes(normalizedResourceName)))
-              );
-
-              if (isExactMatch || isSubstringMatch) {
-                const suggestion = {
-                  resourceName,
-                  suggestedResourceName: standardResourceName,
-                  strategy: MATCHING_STRATEGIES.SUBSTRING,
-                  ddWikiUrl: getDDWikiUrlForResourceName(standardResourceName)
-                };
-
-                if (isExactMatch) {
-                  suggestion.exactMatch = true;
+        if (!ignoreResourceMapping) {
+          if (resourceSuggestions?.length) {
+            //check for human-based suggestions first
+            POSSIBLE_VARIATIONS.resources.push(
+              ...(resourceSuggestions.flatMap(({ suggestedResourceName, ...suggestion }) => {
+                if (!metadataReportMap?.[suggestedResourceName]) {
+                  return [
+                    {
+                      resourceName,
+                      suggestedResourceName,
+                      strategy: MATCHING_STRATEGIES.SUGGESTION,
+                      ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName: suggestedResourceName }),
+                      ...suggestion
+                    }
+                  ];
+                } else {
+                  return [];
                 }
+              }) ?? [])
+            );
+          } else {
+            //use machine techniques
+            Object.keys(standardMetadataMap).forEach(standardResourceName => {
+              const normalizedStandardResourceName = normalizeDataElementName(standardResourceName),
+                normalizedResourceName = normalizeDataElementName(resourceName);
 
-                POSSIBLE_VARIATIONS.resources.push(suggestion);
-              } else if (isMinMatchingLength) {
-                const d = distance(normalizedStandardResourceName, normalizedResourceName),
-                  maxDistance = Math.floor(fuzziness * resourceName?.length);
+              const hasStandardResource = !!metadataReportMap?.[standardResourceName];
 
-                if (d <= maxDistance) {
+              if (!hasStandardResource) {
+                const isMinMatchingLength = resourceName?.length > MIN_MATCHING_LENGTH;
+                const isExactMatch = !!(resourceName !== standardResourceName && normalizedResourceName === normalizedStandardResourceName);
+
+                const isSubstringMatch = !!(
+                  isMinMatchingLength &&
+                  ((normalizedStandardResourceName?.length > MIN_MATCHING_LENGTH &&
+                    normalizedResourceName.includes(normalizedStandardResourceName)) ||
+                    (normalizedResourceName?.length > MIN_MATCHING_LENGTH &&
+                      normalizedStandardResourceName.includes(normalizedResourceName)))
+                );
+
+                if (isExactMatch || isSubstringMatch) {
                   const suggestion = {
                     resourceName,
                     suggestedResourceName: standardResourceName,
-                    distance: d,
-                    maxDistance,
-                    strategy: MATCHING_STRATEGIES.EDIT_DISTANCE,
-                    ddWikiUrl: getDDWikiUrlForResourceName(standardResourceName)
+                    strategy: MATCHING_STRATEGIES.SUBSTRING,
+                    ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName: standardResourceName })
                   };
 
-                  if (d <= CLOSE_MATCH_DISTANCE) {
-                    suggestion.closeMatch = true;
+                  if (isExactMatch) {
+                    suggestion.exactMatch = true;
                   }
 
                   POSSIBLE_VARIATIONS.resources.push(suggestion);
+                } else if (isMinMatchingLength) {
+                  const d = distance(normalizedStandardResourceName, normalizedResourceName),
+                    maxDistance = Math.floor(fuzziness * resourceName?.length);
+
+                  if (d <= maxDistance) {
+                    const suggestion = {
+                      resourceName,
+                      suggestedResourceName: standardResourceName,
+                      distance: d,
+                      maxDistance,
+                      strategy: MATCHING_STRATEGIES.EDIT_DISTANCE,
+                      ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName: standardResourceName })
+                    };
+
+                    if (d <= CLOSE_MATCH_DISTANCE) {
+                      suggestion.closeMatch = true;
+                    }
+
+                    POSSIBLE_VARIATIONS.resources.push(suggestion);
+                  }
                 }
               }
-            }
-          });
+            });
+          }
         }
       } else {
-        //found standard resource - check field name variations
+        // Standard Resource - Process each field
         Object.keys(metadataReportMap?.[resourceName] ?? {}).forEach(fieldName => {
           const isStandardField = !!standardMetadataMap?.[resourceName]?.[fieldName] ?? false;
+          const { isIgnored: ignoreFieldMapping = false, suggestions: fieldSuggestions = [] } =
+            suggestionsMap?.[resourceName]?.[fieldName] ?? {};
 
           if (!isStandardField) {
-            const localFieldNameSuggestions = suggestionsMap?.[resourceName]?.[fieldName]?.suggestions ?? [],
-              hasLocalFieldNameSuggestions = !!(localFieldNameSuggestions && localFieldNameSuggestions?.length) ?? false;
-
-            // try looking in suggestions map
-            if (hasLocalFieldNameSuggestions) {
-              // for each suggestion, only use it if the suggested item isn't already there...
-              const remainingSuggestions =
-                localFieldNameSuggestions.flatMap(({ suggestedResourceName, suggestedFieldName, ...suggestion }) => {
-                  if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]) {
-                    return [
-                      {
-                        resourceName,
-                        fieldName,
-                        suggestedResourceName,
-                        suggestedFieldName,
-                        strategy: MATCHING_STRATEGIES.SUGGESTION,
-                        ddWikiUrl: getDDWikiUrlForFieldName(suggestedResourceName, suggestedFieldName),
-                        ...suggestion
-                      }
-                    ];
-                  } else {
-                    return [];
-                  }
-                }) ?? [];
-
-              if (remainingSuggestions?.length) {
-                POSSIBLE_VARIATIONS.fields.push(...remainingSuggestions);
-              }
-            } else {
-              const isExpansion = !!metadataReportMap?.[resourceName]?.[fieldName]?.isExpansion ?? false;
-
-              if (!isExpansion) {
-                //otherwise, field was not found in reference metadata - look for variations
-                Object.keys(standardMetadataMap?.[resourceName] ?? {}).forEach(standardFieldName => {
-                  const isStandardExpansion = !!standardMetadataMap?.[resourceName]?.[standardFieldName]?.isExpansion ?? false;
-
-                  // skip standard expansions when searching for fields
-                  if (!isStandardExpansion) {
-                    //case-insensitive, no special characters
-                    const normalizedFieldName = normalizeDataElementName(fieldName);
-                    const normalizedStandardFieldName = normalizeDataElementName(standardFieldName);
-
-                    const isMinMatchingLength = fieldName?.length > MIN_MATCHING_LENGTH;
-                    const isExactMatch = !!(normalizedFieldName === normalizedStandardFieldName && fieldName !== standardFieldName);
-                    const hasStandardField = !!metadataReportMap?.[resourceName]?.[standardFieldName] ?? false;
-
-                    const isSubstringMatch = !!(
-                      isMinMatchingLength &&
-                      ((normalizedFieldName?.length > MIN_MATCHING_LENGTH && normalizedStandardFieldName.includes(normalizedFieldName)) ||
-                        (normalizedStandardFieldName?.length > MIN_MATCHING_LENGTH &&
-                          normalizedFieldName.includes(normalizedStandardFieldName)))
-                    );
-
-                    if (!hasStandardField) {
-                      //allow substring matching for anything greater than the minimum matching length
-                      //unless the case-insensitive substring matches exactly
-                      if (isSubstringMatch || isExactMatch) {
-                        // Only add suggestion to the map if a local field with a similar name
-                        // wasn't already present in standard form
-
-                        const suggestion = {
+            if (!ignoreFieldMapping) {
+              if (fieldSuggestions?.length) {
+                POSSIBLE_VARIATIONS.fields.push(
+                  ...(fieldSuggestions.flatMap(({ suggestedResourceName, suggestedFieldName, ...suggestion }) => {
+                    if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]) {
+                      return [
+                        {
                           resourceName,
                           fieldName,
-                          suggestedFieldName: standardFieldName,
-                          strategy: MATCHING_STRATEGIES.SUBSTRING,
-                          ddWikiUrl: getDDWikiUrlForFieldName(resourceName, standardFieldName)
-                        };
-
-                        if (isExactMatch) {
-                          suggestion.exactMatch = true;
-
-                          // add any exact matches to the head of the list
-                          POSSIBLE_VARIATIONS.fields.unshift(suggestion);
-                        } else {
-                          POSSIBLE_VARIATIONS.fields.push(suggestion);
+                          suggestedResourceName,
+                          suggestedFieldName,
+                          strategy: MATCHING_STRATEGIES.SUGGESTION,
+                          ddWikiUrl: getDDWikiUrl({
+                            standardMetadataMap,
+                            resourceName: suggestedResourceName,
+                            fieldName: suggestedFieldName
+                          }),
+                          ...suggestion
                         }
-                      } else if (isMinMatchingLength) {
-                        // Use Edit Distance matching if a substring match wasn't found
-                        // https://en.wikipedia.org/wiki/Edit_distance
-                        // https://en.wikipedia.org/wiki/Levenshtein_distance
-                        // https://github.com/ka-weihe/fastest-levenshtein
-                        const d = distance(normalizedFieldName, normalizedStandardFieldName),
-                          maxDistance = Math.floor(fuzziness * fieldName?.length);
+                      ];
+                    } else {
+                      return [];
+                    }
+                  }) ?? [])
+                );
+              } else {
+                const isExpansion = !!metadataReportMap?.[resourceName]?.[fieldName]?.isExpansion ?? false;
 
-                        if (d <= maxDistance) {
+                if (!isExpansion) {
+                  //otherwise, field was not found in reference metadata - look for variations
+                  Object.keys(standardMetadataMap?.[resourceName] ?? {}).forEach(standardFieldName => {
+                    const isStandardExpansion = !!standardMetadataMap?.[resourceName]?.[standardFieldName]?.isExpansion ?? false;
+
+                    // skip standard expansions when searching for fields
+                    if (!isStandardExpansion) {
+                      //case-insensitive, no special characters
+                      const normalizedFieldName = normalizeDataElementName(fieldName);
+                      const normalizedStandardFieldName = normalizeDataElementName(standardFieldName);
+
+                      const isMinMatchingLength = fieldName?.length > MIN_MATCHING_LENGTH;
+                      const isExactMatch = !!(normalizedFieldName === normalizedStandardFieldName && fieldName !== standardFieldName);
+                      const hasStandardField = !!metadataReportMap?.[resourceName]?.[standardFieldName] ?? false;
+
+                      const isSubstringMatch = !!(
+                        isMinMatchingLength &&
+                        ((normalizedFieldName?.length > MIN_MATCHING_LENGTH && normalizedStandardFieldName.includes(normalizedFieldName)) ||
+                          (normalizedStandardFieldName?.length > MIN_MATCHING_LENGTH &&
+                            normalizedFieldName.includes(normalizedStandardFieldName)))
+                      );
+
+                      if (!hasStandardField) {
+                        //allow substring matching for anything greater than the minimum matching length
+                        //unless the case-insensitive substring matches exactly
+                        if (isSubstringMatch || isExactMatch) {
+                          // Only add suggestion to the map if a local field with a similar name
+                          // wasn't already present in standard form
+
                           const suggestion = {
                             resourceName,
                             fieldName,
                             suggestedFieldName: standardFieldName,
-                            distance: d,
-                            maxDistance,
-                            strategy: MATCHING_STRATEGIES.EDIT_DISTANCE,
-                            ddWikiUrl: getDDWikiUrlForFieldName(resourceName, standardFieldName)
+                            strategy: MATCHING_STRATEGIES.SUBSTRING,
+                            ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName, fieldName: standardFieldName })
                           };
 
-                          if (d <= CLOSE_MATCH_DISTANCE) {
-                            suggestion.closeMatch = true;
-                          }
+                          if (isExactMatch) {
+                            suggestion.exactMatch = true;
 
-                          POSSIBLE_VARIATIONS.fields.push(suggestion);
+                            // add any exact matches to the head of the list
+                            POSSIBLE_VARIATIONS.fields.unshift(suggestion);
+                          } else {
+                            POSSIBLE_VARIATIONS.fields.push(suggestion);
+                          }
+                        } else if (isMinMatchingLength) {
+                          // Use Edit Distance matching if a substring match wasn't found
+                          // https://en.wikipedia.org/wiki/Edit_distance
+                          // https://en.wikipedia.org/wiki/Levenshtein_distance
+                          // https://github.com/ka-weihe/fastest-levenshtein
+                          const d = distance(normalizedFieldName, normalizedStandardFieldName),
+                            maxDistance = Math.floor(fuzziness * fieldName?.length);
+
+                          if (d <= maxDistance) {
+                            const suggestion = {
+                              resourceName,
+                              fieldName,
+                              suggestedFieldName: standardFieldName,
+                              distance: d,
+                              maxDistance,
+                              strategy: MATCHING_STRATEGIES.EDIT_DISTANCE,
+                              ddWikiUrl: getDDWikiUrl({ standardMetadataMap, resourceName, fieldName: standardFieldName })
+                            };
+
+                            if (d <= CLOSE_MATCH_DISTANCE) {
+                              suggestion.closeMatch = true;
+                            }
+
+                            POSSIBLE_VARIATIONS.fields.push(suggestion);
+                          }
                         }
                       }
                     }
-                  }
-                });
-              } else {
-                // TODO
-                // console.log(`TODO: Expansion found! Resource: '${resourceName}', Field: '${fieldName}'`);
+                  });
+                } else {
+                  // TODO
+                  // console.log(`TODO: Expansion found! Resource: '${resourceName}', Field: '${fieldName}'`);
+                }
               }
             }
           } else {
             //standard field - if lookup field then try and process the nested lookups
             const { lookupValues = {}, legacyODataValues = {} } = metadataReportMap?.[resourceName]?.[fieldName] || {};
 
+            const standardLookupValues = standardMetadataMap?.[resourceName]?.[fieldName]?.lookupValues || {};
+
             //check lookupValues
             Object.values(lookupValues ?? {}).forEach(({ lookupValue }) => {
-              const standardLookupValues = standardMetadataMap?.[resourceName]?.[fieldName]?.lookupValues || {},
-                isStandardLookupValue = !!standardLookupValues?.[lookupValue] ?? false;
+              const isStandardLookupValue = !!standardLookupValues?.[lookupValue] ?? false;
+              const { isIgnored: ignoreLookupValueMapping = false, suggestions: lookupValueSuggestions = [] } =
+                suggestionsMap?.[resourceName]?.[fieldName]?.[lookupValue] ?? {};
 
-              //if the lookupValue doesn't exist in the standard metadata map then try and find matches
               if (!isStandardLookupValue) {
-                const localLookupValueSuggestions = suggestionsMap?.[resourceName]?.[fieldName]?.[lookupValue]?.suggestions ?? [],
-                  hasLocalLookupValueSuggestions = !!(localLookupValueSuggestions && localLookupValueSuggestions?.length) ?? false;
-
-                if (hasLocalLookupValueSuggestions) {
-                  // for each suggestion, only use it if the suggested item isn't already there...
-                  const remainingSuggestions =
-                    localLookupValueSuggestions.flatMap(
-                      ({ suggestedResourceName, suggestedFieldName, suggestedLookupValue, ...suggestion }) => {
-                        if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLookupValue]) {
-                          return [
-                            {
-                              resourceName,
-                              fieldName,
-                              lookupValue,
-                              suggestedResourceName,
-                              suggestedFieldName,
-                              suggestedLookupValue,
-                              strategy: MATCHING_STRATEGIES.SUGGESTION,
-                              ddWikiUrl: getDDWikiUrlForLookupValue(suggestedResourceName, suggestedFieldName, suggestedLookupValue),
-                              ...suggestion
-                            }
-                          ];
-                        } else {
-                          return [];
+                if (!ignoreLookupValueMapping) {
+                  if (lookupValueSuggestions?.length) {
+                    // use human suggestions
+                    POSSIBLE_VARIATIONS.lookupValues.push(
+                      ...(lookupValueSuggestions.flatMap(
+                        ({ suggestedResourceName, suggestedFieldName, suggestedLookupValue, ...suggestion }) => {
+                          if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLookupValue]) {
+                            return [
+                              {
+                                resourceName,
+                                fieldName,
+                                lookupValue,
+                                suggestedResourceName,
+                                suggestedFieldName,
+                                suggestedLookupValue,
+                                strategy: MATCHING_STRATEGIES.SUGGESTION,
+                                ddWikiUrl: getDDWikiUrl({
+                                  standardMetadataMap,
+                                  resourceName: suggestedResourceName,
+                                  fieldName: suggestedFieldName,
+                                  lookupValue: suggestedLookupValue
+                                }),
+                                ...suggestion
+                              }
+                            ];
+                          } else {
+                            return [];
+                          }
                         }
-                      }
-                    ) ?? [];
-
-                  if (remainingSuggestions?.length) {
-                    POSSIBLE_VARIATIONS.lookupValues.push(...remainingSuggestions);
-                  }
-                } else {
-                  //look through the existing lookupValues to see if we can find matches
-                  Object.keys(standardLookupValues).forEach(standardLookupValue => {
-                    const normalizedLookupValue = normalizeDataElementName(lookupValue);
-                    const normalizedStandardLookupValue = normalizeDataElementName(standardLookupValue);
-
-                    const isMinMatchingLength = lookupValue?.length > MIN_MATCHING_LENGTH;
-                    const isExactMatch = !!(lookupValue !== standardLookupValue && normalizedLookupValue === normalizedStandardLookupValue);
-                    const hasStandardLookupValue =
-                      !!metadataReportMap?.[resourceName]?.[fieldName]?.lookupValues?.[standardLookupValue] ?? false;
-
-                    const isSubstringMatch = !!(
-                      isMinMatchingLength &&
-                      ((normalizedStandardLookupValue?.length > MIN_MATCHING_LENGTH &&
-                        normalizedLookupValue.includes(normalizedStandardLookupValue)) ||
-                        (normalizedLookupValue?.length > MIN_MATCHING_LENGTH &&
-                          normalizedStandardLookupValue.includes(normalizedLookupValue)))
+                      ) ?? [])
                     );
+                  } else {
+                    // use machine techniques
+                    Object.keys(standardLookupValues).forEach(standardLookupValue => {
+                      const normalizedLookupValue = normalizeDataElementName(lookupValue);
+                      const normalizedStandardLookupValue = normalizeDataElementName(standardLookupValue);
 
-                    if (!hasStandardLookupValue) {
-                      //first check case-insensitive substring matches
-                      if (isExactMatch || isSubstringMatch) {
-                        const suggestion = {
-                          resourceName,
-                          fieldName,
-                          lookupValue,
-                          suggestedLookupValue: standardLookupValue,
-                          matchedOn: MATCHED_ON.LOOKUP_VALUE,
-                          strategy: MATCHING_STRATEGIES.SUBSTRING,
-                          ddWikiUrl: getDDWikiUrlForLookupValue(resourceName, fieldName, standardLookupValue)
-                        };
+                      const isMinMatchingLength = lookupValue?.length > MIN_MATCHING_LENGTH;
+                      const isExactMatch = !!(
+                        lookupValue !== standardLookupValue && normalizedLookupValue === normalizedStandardLookupValue
+                      );
+                      const hasStandardLookupValue =
+                        !!metadataReportMap?.[resourceName]?.[fieldName]?.lookupValues?.[standardLookupValue] ?? false;
 
-                        if (isExactMatch) {
-                          suggestion.exactMatch = true;
+                      const isSubstringMatch = !!(
+                        isMinMatchingLength &&
+                        ((normalizedStandardLookupValue?.length > MIN_MATCHING_LENGTH &&
+                          normalizedLookupValue.includes(normalizedStandardLookupValue)) ||
+                          (normalizedLookupValue?.length > MIN_MATCHING_LENGTH &&
+                            normalizedStandardLookupValue.includes(normalizedLookupValue)))
+                      );
 
-                          // add exact matches at the head of the list
-                          POSSIBLE_VARIATIONS.lookupValues.unshift(suggestion);
-                        } else {
-                          POSSIBLE_VARIATIONS.lookupValues.push(suggestion);
-                        }
-                      } else if (isMinMatchingLength) {
-                        const d = distance(normalizedLookupValue, normalizedStandardLookupValue),
-                          maxDistance = Math.floor(fuzziness * lookupValue?.length);
-
-                        if (!hasStandardLookupValue && d <= maxDistance) {
+                      if (!hasStandardLookupValue) {
+                        //first check case-insensitive substring matches
+                        if (isExactMatch || isSubstringMatch) {
                           const suggestion = {
                             resourceName,
                             fieldName,
                             lookupValue,
-                            distance: d,
-                            maxDistance,
-                            strategy: MATCHING_STRATEGIES.EDIT_DISTANCE
+                            suggestedLookupValue: standardLookupValue,
+                            matchedOn: MATCHED_ON.LOOKUP_VALUE,
+                            strategy: MATCHING_STRATEGIES.SUBSTRING,
+                            ddWikiUrl: getDDWikiUrl({
+                              standardMetadataMap,
+                              resourceName,
+                              fieldName,
+                              lookupValue: standardLookupValue
+                            })
                           };
 
-                          if (lookupValue !== standardLookupValue) {
-                            suggestion.matchedOn = MATCHED_ON.LOOKUP_VALUE;
-                            suggestion.suggestedLookupValue = standardLookupValue;
-                            suggestion.ddWikiUrl = getDDWikiUrlForLookupValue(resourceName, fieldName, standardLookupValue);
-                          }
+                          if (isExactMatch) {
+                            suggestion.exactMatch = true;
 
-                          if (d <= CLOSE_MATCH_DISTANCE) {
-                            suggestion.closeMatch = true;
+                            // add exact matches at the head of the list
+                            POSSIBLE_VARIATIONS.lookupValues.unshift(suggestion);
+                          } else {
+                            POSSIBLE_VARIATIONS.lookupValues.push(suggestion);
                           }
+                        } else if (isMinMatchingLength) {
+                          const d = distance(normalizedLookupValue, normalizedStandardLookupValue),
+                            maxDistance = Math.floor(fuzziness * lookupValue?.length);
 
-                          POSSIBLE_VARIATIONS.lookupValues.push(suggestion);
+                          if (!hasStandardLookupValue && d <= maxDistance) {
+                            const suggestion = {
+                              resourceName,
+                              fieldName,
+                              lookupValue,
+                              distance: d,
+                              maxDistance,
+                              strategy: MATCHING_STRATEGIES.EDIT_DISTANCE
+                            };
+
+                            if (lookupValue !== standardLookupValue) {
+                              suggestion.matchedOn = MATCHED_ON.LOOKUP_VALUE;
+                              suggestion.suggestedLookupValue = standardLookupValue;
+                              suggestion.ddWikiUrl = getDDWikiUrl({
+                                standardMetadataMap,
+                                resourceName,
+                                fieldName,
+                                lookupValue: standardLookupValue
+                              });
+                            }
+
+                            if (d <= CLOSE_MATCH_DISTANCE) {
+                              suggestion.closeMatch = true;
+                            }
+
+                            POSSIBLE_VARIATIONS.lookupValues.push(suggestion);
+                          }
                         }
                       }
-                    }
-                  });
+                    });
+                  }
                 }
               }
             });
 
+            const standardLegacyODataValues = standardMetadataMap?.[resourceName]?.[fieldName]?.legacyODataValues || {};
+
             //check legacyODataValues
             Object.values(legacyODataValues ?? {}).forEach(({ legacyODataValue }) => {
-              const standardLegacyODataValues = standardMetadataMap?.[resourceName]?.[fieldName]?.legacyODataValues || {},
-                isStandardLegacyODataValue = standardLegacyODataValues?.[legacyODataValue] ?? false;
+              const isStandardLegacyODataValue = standardLegacyODataValues?.[legacyODataValue] ?? false;
+              const { isIgnored: ignoreLegacyODataValueMapping = false, suggestions: legacyODataValueSuggestions = [] } =
+                suggestionsMap?.[resourceName]?.[fieldName]?.[legacyODataValue] ?? {};
 
               if (!isStandardLegacyODataValue) {
-                const localODataLookupValueSuggestions = suggestionsMap?.[resourceName]?.[fieldName]?.[legacyODataValue]?.suggestions ?? [],
-                  hasLocalODataLookupValueSuggestions =
-                    (localODataLookupValueSuggestions && localODataLookupValueSuggestions?.length) ?? false;
-
-                if (hasLocalODataLookupValueSuggestions) {
-                  // for each suggestion, only use it if the suggested item isn't already there...
-                  const remainingSuggestions =
-                    localODataLookupValueSuggestions.flatMap(
-                      ({ suggestedResourceName, suggestedFieldName, suggestedLegacyODataValue, ...suggestion }) => {
-                        if (!metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLegacyODataValue]) {
-                          return [
-                            {
-                              resourceName,
-                              fieldName,
-                              legacyODataValue,
-                              suggestedResourceName,
-                              suggestedFieldName,
-                              suggestedLegacyODataValue,
-                              strategy: MATCHING_STRATEGIES.SUGGESTION,
-                              ddWikiUrl: getDDWikiUrlForLookupValue(suggestedResourceName, suggestedFieldName, suggestedLegacyODataValue),
-                              ...suggestion
-                            }
-                          ];
-                        } else {
-                          return [];
+                if (!ignoreLegacyODataValueMapping) {
+                  if (legacyODataValueSuggestions?.length) {
+                    //use human suggestions
+                    POSSIBLE_VARIATIONS.legacyODataValues.push(
+                      ...(legacyODataValueSuggestions.flatMap(
+                        ({ suggestedResourceName, suggestedFieldName, suggestedLegacyODataValue, ...suggestion }) => {
+                          if (
+                            !metadataReportMap?.[suggestedResourceName]?.[suggestedFieldName]?.lookupValues?.[suggestedLegacyODataValue]
+                          ) {
+                            return [
+                              {
+                                resourceName,
+                                fieldName,
+                                legacyODataValue,
+                                suggestedResourceName,
+                                suggestedFieldName,
+                                suggestedLegacyODataValue,
+                                strategy: MATCHING_STRATEGIES.SUGGESTION,
+                                ddWikiUrl: getDDWikiUrl({
+                                  standardMetadataMap,
+                                  resourceName: suggestedResourceName,
+                                  fieldName: suggestedFieldName,
+                                  legacyODataValue: suggestedLegacyODataValue
+                                }),
+                                ...suggestion
+                              }
+                            ];
+                          } else {
+                            return [];
+                          }
                         }
-                      }
-                    ) ?? [];
-
-                  if (remainingSuggestions?.length) {
-                    POSSIBLE_VARIATIONS.legacyODataValues.push(...remainingSuggestions);
-                  }
-                } else {
-                  Object.keys(standardLegacyODataValues).forEach(standardODataLookupValue => {
-                    const normalizedODataValue = normalizeDataElementName(legacyODataValue);
-                    const normalizedStandardODataValue = normalizeDataElementName(standardODataLookupValue);
-
-                    const isMinMatchingLength = legacyODataValue?.length > MIN_MATCHING_LENGTH;
-                    const isExactMatch = !!(
-                      normalizedODataValue === normalizedStandardODataValue && legacyODataValue !== standardODataLookupValue
+                      ) ?? [])
                     );
+                  } else {
+                    Object.keys(standardLegacyODataValues).forEach(standardODataLookupValue => {
+                      const normalizedODataValue = normalizeDataElementName(legacyODataValue);
+                      const normalizedStandardODataValue = normalizeDataElementName(standardODataLookupValue);
 
-                    const hasStandardLegacyODataValue =
-                      !!metadataReportMap?.[resourceName]?.[fieldName]?.legacyODataValues?.[standardODataLookupValue] ?? false;
+                      const isMinMatchingLength = legacyODataValue?.length > MIN_MATCHING_LENGTH;
+                      const isExactMatch = !!(
+                        normalizedODataValue === normalizedStandardODataValue && legacyODataValue !== standardODataLookupValue
+                      );
 
-                    const isSubstringMatch = !!(
-                      isMinMatchingLength &&
-                      ((normalizedStandardODataValue?.length > MIN_MATCHING_LENGTH &&
-                        normalizedODataValue.includes(normalizedStandardODataValue)) ||
-                        (normalizedODataValue?.length > MIN_MATCHING_LENGTH && normalizedStandardODataValue.includes(normalizedODataValue)))
-                    );
+                      const hasStandardLegacyODataValue =
+                        !!metadataReportMap?.[resourceName]?.[fieldName]?.legacyODataValues?.[standardODataLookupValue] ?? false;
 
-                    if (!hasStandardLegacyODataValue) {
-                      if (isExactMatch || isSubstringMatch) {
-                        const suggestion = {
-                          resourceName,
-                          fieldName,
-                          legacyODataValue,
-                          suggestedLegacyODataValue: standardODataLookupValue,
-                          matchedOn: MATCHED_ON.LEGACY_ODATA_VALUE,
-                          strategy: MATCHING_STRATEGIES.SUBSTRING,
-                          ddWikiUrl: getDDWikiUrlForODataLookupValue(resourceName, fieldName, standardODataLookupValue)
-                        };
+                      const isSubstringMatch = !!(
+                        isMinMatchingLength &&
+                        ((normalizedStandardODataValue?.length > MIN_MATCHING_LENGTH &&
+                          normalizedODataValue.includes(normalizedStandardODataValue)) ||
+                          (normalizedODataValue?.length > MIN_MATCHING_LENGTH &&
+                            normalizedStandardODataValue.includes(normalizedODataValue)))
+                      );
 
-                        if (isExactMatch) {
-                          suggestion.exactMatch = true;
-                          POSSIBLE_VARIATIONS.legacyODataValues.unshift(suggestion);
-                        } else {
-                          POSSIBLE_VARIATIONS.legacyODataValues.push(suggestion);
-                        }
-                      } else if (isMinMatchingLength) {
-                        const d = distance(legacyODataValue, standardODataLookupValue),
-                          maxDistance = Math.round(fuzziness * legacyODataValue?.length);
-
-                        if (d <= maxDistance) {
+                      if (!hasStandardLegacyODataValue) {
+                        if (isExactMatch || isSubstringMatch) {
                           const suggestion = {
                             resourceName,
                             fieldName,
                             legacyODataValue,
-                            distance: d,
-                            maxDistance,
-                            strategy: MATCHING_STRATEGIES.EDIT_DISTANCE
+                            suggestedLegacyODataValue: standardODataLookupValue,
+                            matchedOn: MATCHED_ON.LEGACY_ODATA_VALUE,
+                            strategy: MATCHING_STRATEGIES.SUBSTRING,
+                            ddWikiUrl: getDDWikiUrl({
+                              standardMetadataMap,
+                              resourceName,
+                              fieldName,
+                              legacyODataValue: standardODataLookupValue
+                            })
                           };
 
-                          if (legacyODataValue !== standardODataLookupValue) {
-                            suggestion.matchedOn = MATCHED_ON.LEGACY_ODATA_VALUE;
-                            suggestion.suggestedLegacyODataValue = standardODataLookupValue;
-                            suggestion.ddWikiUrl = getDDWikiUrlForODataLookupValue(resourceName, fieldName, standardODataLookupValue);
+                          if (isExactMatch) {
+                            suggestion.exactMatch = true;
+                            POSSIBLE_VARIATIONS.legacyODataValues.unshift(suggestion);
+                          } else {
+                            POSSIBLE_VARIATIONS.legacyODataValues.push(suggestion);
                           }
+                        } else if (isMinMatchingLength) {
+                          const d = distance(legacyODataValue, standardODataLookupValue),
+                            maxDistance = Math.round(fuzziness * legacyODataValue?.length);
 
-                          if (d <= CLOSE_MATCH_DISTANCE) {
-                            suggestion.closeMatch = true;
+                          if (d <= maxDistance) {
+                            const suggestion = {
+                              resourceName,
+                              fieldName,
+                              legacyODataValue,
+                              distance: d,
+                              maxDistance,
+                              strategy: MATCHING_STRATEGIES.EDIT_DISTANCE
+                            };
+
+                            if (legacyODataValue !== standardODataLookupValue) {
+                              suggestion.matchedOn = MATCHED_ON.LEGACY_ODATA_VALUE;
+                              suggestion.suggestedLegacyODataValue = standardODataLookupValue;
+                              suggestion.ddWikiUrl = getDDWikiUrl({
+                                standardMetadataMap,
+                                resourceName,
+                                fieldName,
+                                legacyODataValue: standardODataLookupValue
+                              });
+                            }
+
+                            if (d <= CLOSE_MATCH_DISTANCE) {
+                              suggestion.closeMatch = true;
+                            }
+
+                            POSSIBLE_VARIATIONS.legacyODataValues.push(suggestion);
                           }
-
-                          POSSIBLE_VARIATIONS.legacyODataValues.push(suggestion);
                         }
                       }
-                    }
-                  });
+                    });
+                  }
                 }
               }
             });
@@ -939,7 +971,6 @@ const updateVariations = async ({
     } else {
       throw new Error(errMsg);
     }
-    
   }
 
   if (fromCli) {
@@ -962,5 +993,6 @@ module.exports = {
   computeVariations,
   updateVariations,
   isValidUrl,
-  DEFAULT_FUZZINESS
+  DEFAULT_FUZZINESS,
+  MATCHING_STRATEGIES
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@reso/reso-certification-etl": "github:RESOStandards/reso-certification-etl#f7759b5e378217c42ceb09af09b071901ac3b929",
+        "@reso/reso-certification-etl": "github:RESOStandards/reso-certification-etl#d8c1c62cb83155ea1aca09caf87e38672757b6af",
         "ajv": "^8.12.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
@@ -36,8 +36,8 @@
     },
     "node_modules/@reso/reso-certification-etl": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/RESOStandards/reso-certification-etl.git#f7759b5e378217c42ceb09af09b071901ac3b929",
-      "integrity": "sha512-aQFmSmuRTRteF//IrxK4HtWKuecA5LywEhOdvDD8Ie0MiLBxEZxpEKLeY0wG6WOwGe4FliDmeeBEpHbjNSbk8g==",
+      "resolved": "git+ssh://git@github.com/RESOStandards/reso-certification-etl.git#d8c1c62cb83155ea1aca09caf87e38672757b6af",
+      "integrity": "sha512-GymTW+QB1W7jevGsUuTsfQRgYpzyX4/P5SPBJVM6TpDedZ3wzopdKv7gmJL1myfoRDV1M1IGvJLVerzOeqZY2Q==",
       "license": "See LICENSE in ./LICENSE",
       "engines": {
         "node": ">=18.0.0"
@@ -140,9 +140,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -151,9 +154,10 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1518.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1518.0.tgz",
-      "integrity": "sha512-SknaBH0kvDNsdjGyt8wsAfVky688azgEoLKlPqnLWiA/tJPIpdZ3qUfSFXLO6O9s2aolM8JVAULRSEgBMy57iw==",
+      "version": "2.1584.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1584.0.tgz",
+      "integrity": "sha512-57Qizb+bLOhrBLWQSWw6WXTtbO/lFKzLouHxTfm/QeXm38gs0Q0knFxhdH+sWc/DPPJYSRGy7MNiuQcmsq5zxA==",
+      "hasInstallScript": true,
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -164,7 +168,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.5.0"
+        "xml2js": "0.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -205,11 +209,14 @@
       ]
     },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
@@ -256,13 +263,18 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -403,16 +415,19 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -432,14 +447,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/emoji-regex": {
@@ -447,10 +462,29 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "engines": {
         "node": ">=6"
       }
@@ -480,9 +514,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
-      "integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
+      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
       "funding": [
         {
           "type": "github",
@@ -630,14 +664,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -717,20 +755,20 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -750,11 +788,11 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -764,9 +802,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -901,11 +939,11 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
       "dependencies": {
-        "which-typed-array": "^1.1.11"
+        "which-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1203,6 +1241,14 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -1293,14 +1339,16 @@
       }
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dependencies": {
-        "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1438,15 +1486,15 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-      "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1482,9 +1530,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -1549,9 +1597,9 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.1.1.tgz",
-      "integrity": "sha512-MPxA7oN5cvGV0wzfkeHKF2/+Q4TkMpHSWGRy/96I4Cozljmx0ph91+Muxh6HegEtDC4GftJ8qYDE51vghFiEYA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.1.2.tgz",
+      "integrity": "sha512-621iCPgEG1wXViDZS/L3h9F8TgrdQV1eayJlJ8j5A2SZg8OdY/1DLf+VxNeD+q5QbMFEAbjjR8nITj7g4nKa0Q==",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "pend": "~1.2.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@reso/reso-certification-etl": "github:RESOStandards/reso-certification-etl#f7759b5e378217c42ceb09af09b071901ac3b929",
+    "@reso/reso-certification-etl": "github:RESOStandards/reso-certification-etl#d8c1c62cb83155ea1aca09caf87e38672757b6af",
     "ajv": "^8.12.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^2.1.1",


### PR DESCRIPTION
Closes #117.

* Kept the optimizations to do matching in one pass rather than a second pass with the Variations Service.
* If an item is not ignored, then we will first look for human-based suggestions, then run machine techniques, with the former always taking precedent over the latter.
* If a given suggestion is ignored, it will be removed from the final variations report as well. The Variations Service is required to make these kinds of decisions, otherwise the user may get false negatives from machine-based matching and may not get the complete picture of what's in the Variations Service.
* Will consolidate the code and refactor into a few basic patterns once migrated to TypeScript.

Added new matching strategies for Admin or Fast Track. 