### PR TITLE
#149: Revert OData SimpleIdentifier validation for enums

### DIFF
--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -8,9 +8,6 @@ const { validationContext } = require('./context');
 
 const IGNORE_ENUMS = 'ignoreEnumerations';
 
-const ODATA_SIMPLE_IDENTIFIER_SPEC =
-  'https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_SimpleIdentifier';
-
 /**
  * @param {Object} obj
  * @param {string} obj.inputPath
@@ -188,20 +185,6 @@ const processEnumerations = ({ lookupValue, schema, resourceName, fieldName }) =
 };
 
 /**
- * Validates an identifier (enum value) against the odata simple identifier regex
- *
- * @param {String} enumValue
- * @returns {Boolean}
- */
-const checkValidSimpleIdentifier = enumValue => {
-  /**
-   * spec: https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_SimpleIdentifier
-   */
-  const odataIdentifierRegex = /^(?:[\p{L}\p{Nl}]|_)(?:[\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}]|_){0,127}$/u;
-  return odataIdentifierRegex.test(enumValue);
-};
-
-/**
  * Adds custom handling for 'enum' type keywords. We have to remove
  * 'enum' before adding it again or else ajv throws an error.
  *
@@ -250,16 +233,9 @@ const addCustomValidationForEnum = ajv => {
             },
             message: 'must be equal to one of the allowed values'
           };
-          // if the enum is an OData isFlags enumeration, we should be validating it against the spec
           if (isFlags) {
-            const isValidIdentifier = checkValidSimpleIdentifier(enumValue);
-            if (!isValidIdentifier) {
-              valid.push(false);
-              errorMessage.message = `Invalid OData identifier: ${enumValue}. See OData Simple Identifiers: ${ODATA_SIMPLE_IDENTIFIER_SPEC}`;
-              validate.errors = validate.errors ?? [];
-              validate.errors.push(errorMessage);
-              continue;
-            }
+            // if the enum is an OData isFlags enumeration, we should be validating it against the spec
+            // TODO: we should be validating for OData simple identifier here. check the changes in https://github.com/RESOStandards/reso-certification-utils/pull/146
           }
           if (schema.includes(enumValue)) {
             valid.push(true);

--- a/test/validation.js
+++ b/test/validation.js
@@ -25,9 +25,7 @@ const {
   nestedPayloadErrorWithNullExpansion,
   nestedCollectionPayloadErrorWithNull,
   nestedExpansionTypeError,
-  atFieldPayloadError,
-  invalidOdataIdentifierInvalidPayload,
-  validNonStringNonIsflagsPayload
+  atFieldPayloadError
 } = require('./schema/payload-samples');
 
 describe('Schema validation tests', async () => {
@@ -477,59 +475,5 @@ describe('Schema validation tests', async () => {
     });
     const report = combineErrors(errorMap);
     assert.equal(report.totalErrors, 0, 'Error counts did not match');
-  });
-
-  it('should fail with appropriate message in case of failed isflags odata enum check', async () => {
-    let errorMap = {};
-    const expectedField = 'City';
-    const expectedResource = 'Property';
-    const expectedLookupValue = 'invalidSimpleIdentifier$';
-    const expectedErrorMessage = `INVALID OData identifier: ${expectedLookupValue}. See OData Simple Identifiers: https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_SimpleIdentifier`;
-    errorMap = validate({
-      jsonSchema: schema,
-      jsonPayload: invalidOdataIdentifierInvalidPayload,
-      resourceName: 'Property',
-      version: '2.0',
-      errorMap
-    });
-    const report = combineErrors(errorMap);
-    assert.equal(report.items[0].fieldName, expectedField, 'odata simple identfier validation field did not match');
-    assert.equal(report.items[0].resourceName, expectedResource, 'odata simple identfier validation resource did not match');
-    assert.equal(
-      report.items[0].errors[0].occurrences[0].lookupValue,
-      expectedLookupValue,
-      'odata simple identfier validation enum lookup value did not match'
-    );
-    assert.equal(report.totalErrors, 1, 'Error counts did not match');
-    assert.equal(report.items[0].errors[0].message, expectedErrorMessage, 'odata simple identfier validation error message did not match');
-  });
-
-  it('should not fail in cases where enum is not string type but is also not isFlags', async () => {
-    let errorMap = {};
-    metadata.fields.push({
-      fieldName: 'SampleField',
-      resourceName: 'Property',
-      typeName: 'SampleTypeName',
-      type: 'SampleTypeName'
-    });
-    metadata.lookups.push({
-      fieldName: 'SampleField',
-      resourceName: 'Property',
-      lookupName: 'SampleTypeName',
-      lookupValue: 'sampleEnumValue$'
-    });
-    const modifiedSchema = await generateJsonSchema({ metadataReportJson: metadata });
-    errorMap = validate({
-      jsonSchema: modifiedSchema,
-      jsonPayload: validNonStringNonIsflagsPayload,
-      resourceName: 'Property',
-      version: '2.0',
-      errorMap
-    });
-    const report = combineErrors(errorMap);
-    assert.equal(report.totalErrors, 0, 'Error counts did not match');
-
-    metadata.fields.pop();
-    metadata.lookups.pop();
   });
 });


### PR DESCRIPTION
Reverting these changes as SimpleIdentifier validation is done in the metadata validation step (1/4) of DD 2.0 testing so it doesn't need to be done in the schema validation step. 