### PR TITLE
#175: Change handling of expansion related errors

### DIFF
--- a/common.js
+++ b/common.js
@@ -358,7 +358,7 @@ const buildMetadataMap = ({ fields = [], lookups = [] } = {}) => {
       ...fields.reduce(
         (
           acc,
-          { resourceName, fieldName, type, isExpansion = false, isComplexType = false, annotations, typeName = '', nullable = true }
+          { resourceName, fieldName, type, isExpansion = false, isComplexType = false, annotations, typeName = '', nullable = true, isCollection = false }
         ) => {
           if (!acc[resourceName]) {
             acc[resourceName] = {};
@@ -381,6 +381,7 @@ const buildMetadataMap = ({ fields = [], lookups = [] } = {}) => {
             typeName,
             nullable,
             isExpansion,
+            isCollection,
             isLookupField,
             isComplexType: isComplexType || (!isExpansion && !type?.startsWith('Edm.') && !isLookupField),
             ddWikiUrl

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -172,11 +172,20 @@ const parseNestedPropertyForResourceAndField = ({ arr, isValueArray }) => {
  */
 const processEnumerations = ({ lookupValue, schema, resourceName, fieldName }) => {
   const { isStringEnumeration } = schema?.definitions?.MetadataMap?.[resourceName]?.[fieldName]?.lookupValues?.[lookupValue] || {};
+  const { isCollection } = schema?.definitions?.MetadataMap?.[resourceName]?.[fieldName] ?? {};
   // if enum is of string type, no need to split
   if (isStringEnumeration) {
     return { parsedEnumValues: [lookupValue] };
   }
 
+  // if enum isn't string type but is a collection then no need for splitting
+  if (isCollection) {
+    return { parsedEnumValues: [lookupValue] };
+  }
+
+  // if enum contains commas and is not a string enum then it's split on commas
+  // the caller can then match the separated enums with the metadata to check
+  // the validity
   if (lookupValue?.includes(',')) {
     return { parsedEnumValues: lookupValue.split(','), isFlags: true };
   }
@@ -213,13 +222,20 @@ const addCustomValidationForEnum = ajv => {
         isValueArray
       });
 
+      const { isExpansion, typeName } = activeSchema?.definitions?.MetadataMap?.[resourceName]?.[fieldName] ?? {};
+
+      const expandedResource = isExpansion && typeName;
+
+      // eslint-disable-next-line prefer-destructuring
+      const expandedFieldName = isExpansion ? nestedPayloadProperties[3] : null; // this is how ajv orders it's erros. TODO: find a better was to do this.
+
       if (typeof data === 'string') {
         // Process the string to convert it into an array based on the enum definitions.
         const { parsedEnumValues, isFlags } = processEnumerations({
           lookupValue: data,
           enums: schema,
-          resourceName,
-          fieldName,
+          resourceName: expandedResource || resourceName,
+          fieldName: expandedFieldName || fieldName,
           schema: activeSchema
         });
 
@@ -364,6 +380,8 @@ const combineErrors = ({ errorCache, warningsCache, payloadErrors, stats, versio
               count: details.occurrences,
               ...(fileName && { fileName }),
               ...(lookupValue && { lookupValue }),
+              ...(details?.sourceModel && { sourceModel: details.sourceModel }),
+              ...(details?.sourceModelField && { sourceModelField: details.sourceModelField }),
               message: details.message
             }))
           );
@@ -441,12 +459,25 @@ const checkMapParams = (paramName = '') => {
  * @param {String} obj.failedItemValue
  * @param {String} obj.message
  * @param {String} obj.fileName
+ * @param {String} obj.sourceModel
+ * @param {String} obj.sourceModelField
  * @param {{totalErrors: Number, totalWarnings: Number}} obj.stats
  * @param {boolean} obj.isWarning
  *
  * @description Updates the cache with a new error message and increments the error/warnging counts
  */
-const updateCacheAndStats = ({ cache, resourceName, failedItemName, message, fileName, stats, failedItemValue, isWarning }) => {
+const updateCacheAndStats = ({
+  cache,
+  resourceName,
+  failedItemName,
+  message,
+  fileName,
+  stats,
+  failedItemValue,
+  isWarning,
+  sourceModel,
+  sourceModelField
+}) => {
   if (!cache[resourceName]) {
     cache[resourceName] = {};
   }
@@ -469,7 +500,9 @@ const updateCacheAndStats = ({ cache, resourceName, failedItemName, message, fil
       message: !message.startsWith(isWarning ? 'The' : 'Fields')
         ? message.slice(0, message.indexOf(' ')).toUpperCase() + message.slice(message.indexOf(' '), message.length)
         : message,
-      occurrences: 1
+      occurrences: 1,
+      sourceModel,
+      sourceModelField
     };
   } else {
     cache[resourceName][failedItemName][message][fileName][failedItemValue].occurrences++;

--- a/lib/schema/validate.js
+++ b/lib/schema/validate.js
@@ -302,6 +302,7 @@ const generateErrorReport = ({
       if (!instancePath && keyword !== SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) return acc;
       const nestedPayloadProperties = instancePath?.split('/')?.slice(1) || [];
       let parsedResourceName = resourceName;
+      let sourceModel, sourceModelField;
       let failedItemValue;
 
       if (value !== undefined && value !== null) {
@@ -335,18 +336,22 @@ const generateErrorReport = ({
         parsedResourceName = resource;
       }
 
+      const isExpansion = metadataMap?.[parsedResourceName]?.[fieldName]?.isExpansion;
       let resourceNameFromSchemaPath = parseSchemaPath(schemaPath);
-      if (!resourceNameFromSchemaPath && metadataMap?.[parsedResourceName]?.[fieldName]?.isExpansion) {
+      if (!resourceNameFromSchemaPath && isExpansion) {
         resourceNameFromSchemaPath = metadataMap[parsedResourceName][fieldName].typeName;
       }
       // this means the validation error was for an expansion
       if (resourceNameFromSchemaPath && resourceNameFromSchemaPath !== resource) {
         if (params?.additionalProperty) {
-          failedItemName = params?.additionalProperty;
+          if (isExpansion) {
+            sourceModelField = params?.additionalProperty;
+          } else {
+            failedItemName = params?.additionalProperty;
+          }
         }
-        if (resourceNameFromSchemaPath !== failedItemName) {
-          parsedResourceName = resourceNameFromSchemaPath;
-        }
+        sourceModel = resourceNameFromSchemaPath;
+        sourceModelField = sourceModelField ?? nestedPayloadProperties[3]; // ajv ordering for errors
       }
 
       if (keyword === SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) {
@@ -371,7 +376,8 @@ const generateErrorReport = ({
 
       // ignore fields with '@' in the middle of the string
       const normalizedField = normalizeAtField(failedItemName);
-      if (normalizedField !== failedItemName) {
+      const normalizedExpansionField = sourceModelField ? normalizeAtField(sourceModelField) : null;
+      if (normalizedField !== failedItemName || (sourceModelField && sourceModelField !== normalizedExpansionField)) {
         return acc;
       }
 
@@ -406,7 +412,9 @@ const generateErrorReport = ({
           fileName,
           stats,
           failedItemValue,
-          isWarning
+          isWarning,
+          sourceModel,
+          sourceModelField
         });
         return acc;
       }
@@ -418,7 +426,9 @@ const generateErrorReport = ({
         message,
         fileName,
         stats,
-        failedItemValue
+        failedItemValue,
+        sourceModel,
+        sourceModelField
       });
       return acc;
     },

--- a/test/schema/schema-samples.js
+++ b/test/schema/schema-samples.js
@@ -20,7 +20,8 @@ const simpleNonEnumSchema = {
           isComplexType: false,
           ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/AboveGradeFinishedArea+Field',
           typeName: '',
-          nullable: true
+          nullable: true,
+          isCollection: false
         },
         BuyerTeamName: {
           type: 'Edm.String',
@@ -29,7 +30,8 @@ const simpleNonEnumSchema = {
           isComplexType: false,
           ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/BuyerTeamName+Field',
           typeName: '',
-          nullable: true
+          nullable: true,
+          isCollection: false
         }
       }
     }
@@ -64,7 +66,8 @@ const schemaWithMaxLength = {
           isComplexType: false,
           ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/BuyerTeamName+Field',
           typeName: '',
-          nullable: true
+          nullable: true,
+          isCollection: false
         }
       }
     }
@@ -99,7 +102,8 @@ const schemaWithImplicitNullable = {
           isComplexType: false,
           typeName: '',
           ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/BuyerTeamName+Field',
-          nullable: true
+          nullable: true,
+          isCollection: false
         }
       }
     }
@@ -134,7 +138,8 @@ const nonNullableSchema = {
           isComplexType: false,
           typeName: '',
           ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/BuyerTeamName+Field',
-          nullable: false
+          nullable: false,
+          isCollection: false
         }
       }
     }
@@ -167,6 +172,7 @@ const enumFieldsAndLookupsSchema = {
           isLookupField: true,
           isComplexType: false,
           typeName: 'AreaSource',
+          isCollection: false,
           nullable: true,
           ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/AboveGradeFinishedAreaSource+Field',
           lookupValues: {
@@ -343,6 +349,7 @@ const collectionFieldsSchema = {
           isLookupField: true,
           isComplexType: false,
           typeName: 'ExistingLeaseType',
+          isCollection: true,
           nullable: false,
           ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/AvailableLeaseType+Field',
           lookupValues: {
@@ -513,6 +520,7 @@ const expansionFieldsSchema = {
           isComplexType: false,
           typeName: '',
           nullable: true,
+          isCollection: false,
           ddWikiUrl: 'https://ddwiki.reso.org/pages/viewpage.action?pageId=1135641'
         },
         OriginalEntryTimestamp: {
@@ -522,7 +530,8 @@ const expansionFieldsSchema = {
           isComplexType: false,
           typeName: '',
           nullable: true,
-          ddWikiUrl: 'https://ddwiki.reso.org/pages/viewpage.action?pageId=1135646'
+          ddWikiUrl: 'https://ddwiki.reso.org/pages/viewpage.action?pageId=1135646',
+          isCollection: false
         }
       },
       Property: {
@@ -533,7 +542,8 @@ const expansionFieldsSchema = {
           isComplexType: false,
           typeName: 'Teams',
           nullable: true,
-          ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/ListTeam+Field'
+          ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/ListTeam+Field',
+          isCollection: false
         }
       }
     }
@@ -568,6 +578,7 @@ const nullableCollectionFieldsSchema = {
           isExpansion: false,
           isLookupField: true,
           isComplexType: false,
+          isCollection: true,
           typeName: 'ExistingLeaseType',
           nullable: true,
           ddWikiUrl: 'https://ddwiki.reso.org/display/DDW20/AvailableLeaseType+Field',

--- a/test/validation.js
+++ b/test/validation.js
@@ -317,7 +317,7 @@ describe('Schema validation tests', async () => {
     let errorMap = {};
     metadata.fields.find(f => f.type === 'Edm.Int64').maxLength = 5;
     const modifiedSchema = await generateJsonSchema({ metadataReportJson: metadata });
-     
+
     const { AdditionalProperty, ...payload } = additionalPropertyPayload;
     errorMap = validate({
       jsonSchema: modifiedSchema,
@@ -358,8 +358,10 @@ describe('Schema validation tests', async () => {
   it('should show the nested expansion resource and field when expansion field is invalid', async () => {
     let errorMap = {};
     const expectedErrorMessage = 'Fields MUST be advertised in the metadata';
-    const expectedInvalidField = 'Foo';
-    const expectedInvalidResource = 'Member';
+    const expectedInvalidParentField = 'ListAgent';
+    const expectedInvalidParentResource = 'Property';
+    const expectedInvalidSourceModel = 'Member';
+    const expectedInvalidSourceModelField = 'Foo';
     errorMap = validate({
       jsonSchema: schema,
       jsonPayload: nestedPayloadError,
@@ -370,15 +372,21 @@ describe('Schema validation tests', async () => {
     const report = combineErrors(errorMap);
     assert.equal(report.totalErrors, 1, 'Error counts did not match');
     assert.equal(report.items[0].errors[0].message, expectedErrorMessage, 'nested expansion error message did not match');
-    assert.equal(report.items[0].fieldName, expectedInvalidField, 'nested expansion field did not match');
-    assert.equal(report.items[0].resourceName, expectedInvalidResource, 'nested expansion resource did not match');
+    assert.equal(report.items[0].fieldName, expectedInvalidParentField, 'nested expansion field did not match');
+    assert.equal(report.items[0].resourceName, expectedInvalidParentResource, 'nested expansion resource did not match');
+    assert.equal(report.items[0].errors[0].occurrences[0].sourceModel, expectedInvalidSourceModel, 'Expansion resource did not match');
+    assert.equal(
+      report.items[0].errors[0].occurrences[0].sourceModelField,
+      expectedInvalidSourceModelField,
+      'Expansion field did not match'
+    );
   });
 
   it('should not change the payload object', async () => {
     let errorMap = {};
     const expectedErrorMessage = 'Fields MUST be advertised in the metadata';
-    const expectedInvalidField = 'Foo';
-    const expectedInvalidResource = 'Media';
+    const expectedInvalidField = 'Media';
+    const expectedInvalidResource = 'Property';
     const originalPayload = JSON.parse(JSON.stringify(nestedCollectionPayloadError));
     errorMap = validate({
       jsonSchema: schema,
@@ -398,8 +406,10 @@ describe('Schema validation tests', async () => {
   it('should show the nested expansion resource and field when collection expansion field is invalid', async () => {
     let errorMap = {};
     const expectedErrorMessage = 'Fields MUST be advertised in the metadata';
-    const expectedInvalidField = 'Foo';
-    const expectedInvalidResource = 'Media';
+    const expectedInvalidField = 'Media';
+    const expectedInvalidResource = 'Property';
+    const expectedInvalidSourceModel = 'Media';
+    const expectedInvalidSourceModelField = 'Foo';
     errorMap = validate({
       jsonSchema: schema,
       jsonPayload: nestedCollectionPayloadError,
@@ -412,6 +422,12 @@ describe('Schema validation tests', async () => {
     assert.equal(report.items[0].errors[0].message, expectedErrorMessage, 'nested expansion error message did not match');
     assert.equal(report.items[0].fieldName, expectedInvalidField, 'nested expansion field did not match');
     assert.equal(report.items[0].resourceName, expectedInvalidResource, 'nested expansion resource did not match');
+    assert.equal(report.items[0].errors[0].occurrences[0].sourceModel, expectedInvalidSourceModel, 'Expansion resource did not match');
+    assert.equal(
+      report.items[0].errors[0].occurrences[0].sourceModelField,
+      expectedInvalidSourceModelField,
+      'Expansion field did not match'
+    );
   });
 
   it('should not find error when nested non-collection expansion is null', async () => {
@@ -449,7 +465,9 @@ describe('Schema validation tests', async () => {
   it('should find error when nested collection expansion has type error', async () => {
     let errorMap = {};
     const expectedInvalidField = 'ListAgent';
-    const expectedInvalidResource = 'Member';
+    const expectedInvalidResource = 'Property';
+    const expectedInvalidSourceModel = 'Member';
+    const expectedInvalidSourceModelField = 'MemberAlternateId';
     const expectedErrorMessage = 'MUST be string or null but found integer';
     errorMap = validate({
       jsonSchema: schema,
@@ -463,6 +481,12 @@ describe('Schema validation tests', async () => {
     assert.equal(report.items[0].errors[0].message, expectedErrorMessage, 'nested expansion error message did not match');
     assert.equal(report.items[0].fieldName, expectedInvalidField, 'nested expansion field did not match');
     assert.equal(report.items[0].resourceName, expectedInvalidResource, 'nested expansion resource did not match');
+    assert.equal(report.items[0].errors[0].occurrences[0].sourceModel, expectedInvalidSourceModel, 'Expansion resource did not match');
+    assert.equal(
+      report.items[0].errors[0].occurrences[0].sourceModelField,
+      expectedInvalidSourceModelField,
+      'Expansion field did not match'
+    );
   });
 
   it('should ignore errors for payload fields with @ in the middle of the string', async () => {
@@ -481,11 +505,13 @@ describe('Schema validation tests', async () => {
   it('Should correctly classify resource and fields in case of errors with expansion fields', async () => {
     let errorMap = {};
     const expectedField1 = 'BuyerAgentAOR';
-    const expectedField2 = 'Foo';
+    const expectedField2 = 'Media';
     const expectedResource1 = 'Property';
-    const expectedResource2 = 'Media';
+    const expectedResource2 = 'Property';
     const expectedErrorMessage1 = 'MUST be string or null but found array';
     const expectedErrorMessage2 = 'Fields MUST be advertised in the metadata';
+    const expectedInvalidSourceModel = 'Media';
+    const expectedInvalidSourceModelField = 'Foo';
     errorMap = validate({
       jsonSchema: schema,
       jsonPayload: expansionErrorMultiValuePayload,
@@ -503,5 +529,11 @@ describe('Schema validation tests', async () => {
     assert.equal(report.items[1].fieldName, expectedField2, 'nested expansion field did not match');
     assert.equal(report.items[0].resourceName, expectedResource1, 'resource did not match');
     assert.equal(report.items[1].resourceName, expectedResource2, 'nested expansion resource did not match');
+    assert.equal(report.items[1].errors[0].occurrences[0].sourceModel, expectedInvalidSourceModel, 'expansion resource did not match');
+    assert.equal(
+      report.items[1].errors[0].occurrences[0].sourceModelField,
+      expectedInvalidSourceModelField,
+      'expansion field did not match'
+    );
   });
 });


### PR DESCRIPTION
closes #175 

This fixes the main issue from #175 and also adds the new fields `sourceModel` and `sourceModelField` to the schema validation error report. Errors in expanded items will now be reported using these new fields so it's clear which field failed and for which model.

For eg. this is what an error in `Property->ListAgent(Member type)->MemberEmail` would look like:
```json
{
    "description": "RESO Common Format Schema Validation Summary",
    "generatedOn": "2024-08-28T14:10:31.557Z",
    "version": "2.0",
    "totalErrors": 1,
    "totalWarnings": 0,
    "items": [
        {
            "resourceName": "Property",
            "fieldName": "ListAgent",
            "errors": [
                {
                    "message": "MUST be string or null but found integer",
                    "occurrences": [
                        {
                            "count": 1,
                            "fileName": "payload.json",
                            "sourceModel": "Member",
                            "sourceModelField": "MemberEmail"
                        }
                    ]
                }
            ],
            "warnings": []
        }
    ]
}
```