### PR TITLE
#177: Ignored items not working with expansions

### DIFF
--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -123,29 +123,29 @@ const writeFile = async (path, data) => {
  */
 const parseNestedPropertyForResourceAndField = ({ arr, metadataMap, parentResourceName }) => {
   return arr.reduce(
-    (acc, a) => {
-      if (isNaN(Number(a)) && a !== 'value') {
-        if (a === parentResourceName) {
+    (acc, field) => {
+      if (isNaN(Number(field)) && field !== 'value') {
+        if (field === parentResourceName) {
           return {
             ...acc,
-            parentResourceName: a
+            parentResourceName: field
           };
-        } else if (metadataMap?.[parentResourceName]?.[a]?.isExpansion) {
+        } else if (metadataMap?.[parentResourceName]?.[field]?.isExpansion) {
           return {
             ...acc,
-            sourceModel: metadataMap?.[parentResourceName]?.[a]?.typeName,
-            fieldName: a
+            sourceModel: metadataMap?.[parentResourceName]?.[field]?.typeName,
+            fieldName: field
           };
         } else {
           if (acc?.sourceModel) {
             return {
               ...acc,
-              sourceModelField: a
+              sourceModelField: field
             };
           }
           return {
             ...acc,
-            fieldName: a
+            fieldName: field
           };
         }
       } else {

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -117,43 +117,43 @@ const writeFile = async (path, data) => {
  *
  * @param {Object} obj
  * @param {string[]} obj.arr
- * @param {boolean} obj.isValueArray
- * @returns
+ * @param {Object} obj.metadataMap
+ * @param {string} obj.parentResourceName
+ * @returns {{parentResourceName: string, sourceModel: string?, sourceModelField: string?, fieldName: string?}}
  */
-const parseNestedPropertyForResourceAndField = ({ arr, isValueArray }) => {
-  if (isValueArray) {
-    let arrIndexCount = 0;
-    arr.forEach(a => {
-      if (typeof Number(a) === 'number' && !isNaN(Number(a))) arrIndexCount++;
-    });
-    if (arrIndexCount >= 2) {
-      const lastElement = arr.at(-1);
-      if (typeof Number(lastElement) === 'number' && !isNaN(Number(lastElement))) {
-        return {
-          fieldName: arr[2]
-        };
+const parseNestedPropertyForResourceAndField = ({ arr, metadataMap, parentResourceName }) => {
+  return arr.reduce(
+    (acc, a) => {
+      if (isNaN(Number(a)) && a !== 'value') {
+        if (a === parentResourceName) {
+          return {
+            ...acc,
+            parentResourceName: a
+          };
+        } else if (metadataMap?.[parentResourceName]?.[a]?.isExpansion) {
+          return {
+            ...acc,
+            sourceModel: metadataMap?.[parentResourceName]?.[a]?.typeName,
+            fieldName: a
+          };
+        } else {
+          if (acc?.sourceModel) {
+            return {
+              ...acc,
+              sourceModelField: a
+            };
+          }
+          return {
+            ...acc,
+            fieldName: a
+          };
+        }
+      } else {
+        return acc;
       }
-      return {
-        resourceName: arr[2],
-        fieldName: arr[4]
-      };
-    } else {
-      return {
-        fieldName: arr[2]
-      };
-    }
-  } else {
-    if (arr.length === 3) {
-      return {
-        resourceName: arr[0],
-        fieldName: arr[2]
-      };
-    } else {
-      return {
-        fieldName: arr[0]
-      };
-    }
-  }
+    },
+    { parentResourceName, sourceModel: null, sourceModelField: null, fieldName: null }
+  );
 };
 
 /**
@@ -215,29 +215,20 @@ const addCustomValidationForEnum = ajv => {
       const version = validationContext.getVersion();
       const validationConfig = validationContext.getValidationConfig();
       const activeSchema = validationContext.getSchema();
-      const isValueArray = validationContext.getPayloadType() === 'MULTI';
 
-      const { fieldName, resourceName: resource } = parseNestedPropertyForResourceAndField({
+      const { fieldName, sourceModel, sourceModelField } = parseNestedPropertyForResourceAndField({
         arr: nestedPayloadProperties,
-        isValueArray
+        metadataMap: activeSchema?.definitions?.MetadataMap ?? {},
+        parentResourceName: resourceName
       });
-
-      const maybeExpandedResource = resource && resource !== resourceName ? resource : null;
-
-      const { isExpansion, typeName } = activeSchema?.definitions?.MetadataMap?.[resourceName]?.[maybeExpandedResource || fieldName] ?? {};
-
-      const expandedResource = isExpansion && typeName;
-
-      // eslint-disable-next-line prefer-destructuring
-      const expandedFieldName = isExpansion ? (maybeExpandedResource ? fieldName : nestedPayloadProperties[3]) : null; // this is how ajv orders it's erros. TODO: find a better was to do this.
 
       if (typeof data === 'string') {
         // Process the string to convert it into an array based on the enum definitions.
         const { parsedEnumValues, isFlags } = processEnumerations({
           lookupValue: data,
           enums: schema,
-          resourceName: expandedResource || resourceName,
-          fieldName: expandedFieldName || fieldName,
+          resourceName: sourceModelField || resourceName,
+          fieldName: sourceModelField || fieldName,
           schema: activeSchema
         });
 
@@ -260,9 +251,11 @@ const addCustomValidationForEnum = ajv => {
           } else {
             // Collect the needed error data if validation fails
             valid.push(false);
-            if (validationConfig?.[version]?.[expandedResource || resourceName]?.[expandedFieldName || fieldName]?.[IGNORE_ENUMS]) {
+            if (validationConfig?.[version]?.[sourceModel || resourceName]?.[sourceModelField || fieldName]?.[IGNORE_ENUMS]) {
               // convert to warning is the failed field is ingored in the validation config
-              errorMessage.message = `The following enumerations in the ${fieldName} Field were not advertised. This will fail in Data Dictionary 2.1`;
+              errorMessage.message = `The following enumerations in the ${
+                sourceModelField || fieldName
+              } Field were not advertised. This will fail in Data Dictionary 2.1`;
               errorMessage.isWarning = true;
             }
             validate.errors = validate.errors ?? [];
@@ -438,20 +431,6 @@ const combineErrors = ({ errorCache, warningsCache, payloadErrors, stats, versio
   };
 };
 
-const parseSchemaPath = (path = '') => {
-  const schemaPathParts = path.split('/');
-  if (schemaPathParts?.[1] === 'definitions') {
-    return schemaPathParts[2];
-  }
-  return null;
-};
-
-const checkMapParams = (paramName = '') => {
-  if (paramName === '__proto__' || paramName === 'constructor' || paramName === 'prototype') {
-    throw new Error(`Invalid property value: '${paramName}'`);
-  }
-};
-
 /**
  *
  * @param {Object} obj
@@ -570,8 +549,6 @@ module.exports = {
   getValidDataDictionaryVersions,
   isValidDataDictionaryVersion,
   combineErrors,
-  parseSchemaPath,
-  checkMapParams,
   updateCacheAndStats,
   getResourceAndVersion,
   getMaxLengthMessage

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -217,17 +217,19 @@ const addCustomValidationForEnum = ajv => {
       const activeSchema = validationContext.getSchema();
       const isValueArray = validationContext.getPayloadType() === 'MULTI';
 
-      const { fieldName } = parseNestedPropertyForResourceAndField({
+      const { fieldName, resourceName: resource } = parseNestedPropertyForResourceAndField({
         arr: nestedPayloadProperties,
         isValueArray
       });
 
-      const { isExpansion, typeName } = activeSchema?.definitions?.MetadataMap?.[resourceName]?.[fieldName] ?? {};
+      const maybeExpandedResource = resource && resource !== resourceName ? resource : null;
+
+      const { isExpansion, typeName } = activeSchema?.definitions?.MetadataMap?.[resourceName]?.[maybeExpandedResource || fieldName] ?? {};
 
       const expandedResource = isExpansion && typeName;
 
       // eslint-disable-next-line prefer-destructuring
-      const expandedFieldName = isExpansion ? nestedPayloadProperties[3] : null; // this is how ajv orders it's erros. TODO: find a better was to do this.
+      const expandedFieldName = isExpansion ? (maybeExpandedResource ? fieldName : nestedPayloadProperties[3]) : null; // this is how ajv orders it's erros. TODO: find a better was to do this.
 
       if (typeof data === 'string') {
         // Process the string to convert it into an array based on the enum definitions.
@@ -258,7 +260,7 @@ const addCustomValidationForEnum = ajv => {
           } else {
             // Collect the needed error data if validation fails
             valid.push(false);
-            if (validationConfig?.[version]?.[resourceName]?.[fieldName]?.[IGNORE_ENUMS]) {
+            if (validationConfig?.[version]?.[expandedResource || resourceName]?.[expandedFieldName || fieldName]?.[IGNORE_ENUMS]) {
               // convert to warning is the failed field is ingored in the validation config
               errorMessage.message = `The following enumerations in the ${fieldName} Field were not advertised. This will fail in Data Dictionary 2.1`;
               errorMessage.isWarning = true;

--- a/lib/schema/validate.js
+++ b/lib/schema/validate.js
@@ -55,9 +55,9 @@ const ORIGINAL_SCHEMA = 'original_schema';
  * @returns Intermediate error and warning caches along with stats. Can be combined later using `combineErrors`
  */
 const validate = ({
-  jsonSchema = {},
+  jsonSchema: schema = {},
   resourceName = 'Property',
-  jsonPayload,
+  jsonPayload: payload,
   errorMap = {},
   fileName = '',
   version,
@@ -65,9 +65,8 @@ const validate = ({
   validationConfig = {}
 } = {}) => {
   const { stats = { totalErrors: 0, totalWarnings: 0 }, errorCache = {}, warningsCache = {}, payloadErrors = {} } = errorMap;
-  const schema = jsonSchema;
+
   const oldOneOf = structuredClone(schema.oneOf);
-  const payload = jsonPayload;
   let schemaId;
 
   validationContext.setValidationConfig(validationConfig);
@@ -162,32 +161,7 @@ const validate = ({
   const validate = ajv.compile(cachedSchema);
   const valid = validate(payload);
 
-  // Update the error message in case of type mismatch
   if (!valid) {
-    for (const error of validate.errors) {
-      if (error.keyword === SCHEMA_ERROR_KEYWORDS.TYPE) {
-        const nestedPayloadProperties = error?.instancePath?.split('/')?.slice(1) || [];
-
-        let resolvedKeyword = error.keyword;
-        if (error.keyword === SCHEMA_ERROR_KEYWORDS.ERROR_MESSAGE) {
-          resolvedKeyword = error?.params?.errors?.[0]?.keyword || resolvedKeyword;
-        }
-        // find corresponding value in the payload
-        let failedItemValue = nestedPayloadProperties.reduce((acc, curr) => {
-          if (!acc && payload[curr] !== undefined) return payload[curr];
-          return acc?.[curr] !== undefined ? acc?.[curr] : acc;
-        }, null);
-
-        // additional property errors need to be transformed in or else they will pollute the final error output.
-        if (failedItemValue?.['constructor'] === Object && resolvedKeyword === SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) {
-          failedItemValue = SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES;
-        }
-        const schemaType = error?.params?.type;
-        const schemaTypeFormatted = Array.isArray(error?.params?.type) ? schemaType.join(' or ') : schemaType;
-        error.message = `MUST be ${schemaTypeFormatted} but found ${determineType(failedItemValue)}`;
-        error.transformedValue = determineType(failedItemValue);
-      }
-    }
     generateErrorReport({
       validate,
       json: payload,
@@ -298,22 +272,25 @@ const generateErrorReport = ({
   validate.errors.reduce((acc, { instancePath, message, keyword, params, failedItemValue: value, isWarning, transformedValue }) => {
     if (!instancePath && keyword !== SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) return acc;
     const nestedPayloadProperties = instancePath?.split('/')?.slice(1) || [];
-    let failedItemValue;
+    let failedItemValue = '';
 
     const schema = validationContext.getSchema();
 
     if (value !== undefined && value !== null) {
       failedItemValue = value;
     } else {
-      if (keyword === SCHEMA_ERROR_KEYWORDS.ENUM) {
-        // grab the nested value of the failed item from the payload
-        failedItemValue = nestedPayloadProperties.reduce((val, curr) => {
-          if (!val && json[curr] !== undefined) return json[curr];
-          return val?.[curr] || val;
-        }, null);
-      } else {
-        failedItemValue = '';
-      }
+      // grab the nested value of the failed item from the payload
+      failedItemValue = nestedPayloadProperties.reduce((val, curr) => {
+        if (!val && json[curr] !== undefined) return json[curr];
+        return val?.[curr] !== undefined ? val?.[curr] : val;
+      }, null);
+    }
+
+    if (keyword === SCHEMA_ERROR_KEYWORDS.TYPE) {
+      const schemaType = params?.type;
+      const schemaTypeFormatted = Array.isArray(schemaType) ? schemaType.join(' or ') : schemaType;
+      message = `MUST be ${schemaTypeFormatted} but found ${determineType(failedItemValue)}`;
+      transformedValue = determineType(failedItemValue);
     }
 
     // eslint-disable-next-line prefer-const
@@ -322,6 +299,7 @@ const generateErrorReport = ({
       metadataMap: schema?.definitions?.MetadataMap,
       parentResourceName: resourceName
     });
+
     if (
       keyword === SCHEMA_ERROR_KEYWORDS.TYPE &&
       params?.type === SCHEMA_ERROR_KEYWORDS.OBJECT &&
@@ -341,6 +319,7 @@ const generateErrorReport = ({
     }
 
     if (keyword === SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) {
+      failedItemValue = '';
       message = isResoDataDictionarySchema
         ? `Additional fields found that are not part of Data Dictionary ${version}`
         : 'Fields MUST be advertised in the metadata';

--- a/lib/schema/validate.js
+++ b/lib/schema/validate.js
@@ -14,8 +14,6 @@ const {
   getValidDataDictionaryVersions,
   isValidDataDictionaryVersion,
   combineErrors,
-  parseSchemaPath,
-  checkMapParams,
   updateCacheAndStats,
   getResourceAndVersion,
   getMaxLengthMessage,
@@ -297,143 +295,126 @@ const generateErrorReport = ({
   isRCF,
   metadataMap
 }) => {
-  validate.errors.reduce(
-    (acc, { instancePath, message, keyword, params, failedItemValue: value, isWarning, schemaPath, transformedValue }) => {
-      if (!instancePath && keyword !== SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) return acc;
-      const nestedPayloadProperties = instancePath?.split('/')?.slice(1) || [];
-      let parsedResourceName = resourceName;
-      let sourceModel, sourceModelField;
-      let failedItemValue;
+  validate.errors.reduce((acc, { instancePath, message, keyword, params, failedItemValue: value, isWarning, transformedValue }) => {
+    if (!instancePath && keyword !== SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) return acc;
+    const nestedPayloadProperties = instancePath?.split('/')?.slice(1) || [];
+    let failedItemValue;
 
-      if (value !== undefined && value !== null) {
-        failedItemValue = value;
+    const schema = validationContext.getSchema();
+
+    if (value !== undefined && value !== null) {
+      failedItemValue = value;
+    } else {
+      if (keyword === SCHEMA_ERROR_KEYWORDS.ENUM) {
+        // grab the nested value of the failed item from the payload
+        failedItemValue = nestedPayloadProperties.reduce((val, curr) => {
+          if (!val && json[curr] !== undefined) return json[curr];
+          return val?.[curr] || val;
+        }, null);
       } else {
-        if (keyword === SCHEMA_ERROR_KEYWORDS.ENUM) {
-          failedItemValue = nestedPayloadProperties.reduce((val, curr) => {
-            if (!val && json[curr] !== undefined) return json[curr];
-            return val?.[curr] || val;
-          }, null);
-        } else {
-          failedItemValue = '';
-        }
+        failedItemValue = '';
       }
+    }
 
-      const { fieldName, resourceName: resource } = parseNestedPropertyForResourceAndField({
-        arr: nestedPayloadProperties,
-        isValueArray: !!json.value
-      });
-      if (
-        keyword === SCHEMA_ERROR_KEYWORDS.TYPE &&
-        params?.type === SCHEMA_ERROR_KEYWORDS.OBJECT &&
-        metadataMap?.[resourceName]?.[fieldName]?.nullable &&
-        transformedValue === SCHEMA_ERROR_KEYWORDS.NULL
-      ) {
-        return acc;
-      }
+    // eslint-disable-next-line prefer-const
+    let { fieldName, sourceModel, sourceModelField } = parseNestedPropertyForResourceAndField({
+      arr: nestedPayloadProperties,
+      metadataMap: schema?.definitions?.MetadataMap,
+      parentResourceName: resourceName
+    });
+    if (
+      keyword === SCHEMA_ERROR_KEYWORDS.TYPE &&
+      params?.type === SCHEMA_ERROR_KEYWORDS.OBJECT &&
+      metadataMap?.[resourceName]?.[fieldName]?.nullable &&
+      transformedValue === SCHEMA_ERROR_KEYWORDS.NULL
+    ) {
+      return acc;
+    }
 
-      let failedItemName = fieldName;
-      if (resource) {
-        parsedResourceName = resource;
+    let failedItemName = fieldName;
+    if (params?.additionalProperty) {
+      if (!!sourceModel) {
+        sourceModelField = params?.additionalProperty;
+      } else {
+        failedItemName = params?.additionalProperty;
       }
+    }
 
-      const isExpansion = metadataMap?.[parsedResourceName]?.[fieldName]?.isExpansion;
-      let resourceNameFromSchemaPath = parseSchemaPath(schemaPath);
-      if (!resourceNameFromSchemaPath && isExpansion) {
-        resourceNameFromSchemaPath = metadataMap[parsedResourceName][fieldName].typeName;
-      }
-      // this means the validation error was for an expansion
-      if (resourceNameFromSchemaPath && resourceNameFromSchemaPath !== resource) {
-        if (params?.additionalProperty) {
-          if (isExpansion) {
-            sourceModelField = params?.additionalProperty;
-          } else {
-            failedItemName = params?.additionalProperty;
-          }
-        }
-        sourceModel = resourceNameFromSchemaPath;
-        sourceModelField = sourceModelField ?? nestedPayloadProperties[3]; // ajv ordering for errors
-      }
+    if (keyword === SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) {
+      message = isResoDataDictionarySchema
+        ? `Additional fields found that are not part of Data Dictionary ${version}`
+        : 'Fields MUST be advertised in the metadata';
+    }
 
+    if (!failedItemName) {
       if (keyword === SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) {
+        failedItemName = params?.additionalProperty;
         message = isResoDataDictionarySchema
           ? `Additional fields found that are not part of Data Dictionary ${version}`
           : 'Fields MUST be advertised in the metadata';
       }
+    }
 
-      if (!failedItemName) {
-        if (keyword === SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) {
-          failedItemName = params?.additionalProperty;
-          message = isResoDataDictionarySchema
-            ? `Additional fields found that are not part of Data Dictionary ${version}`
-            : 'Fields MUST be advertised in the metadata';
-        }
+    if (['@odata', '@reso'].some(c => failedItemName.startsWith(c))) {
+      // we don't want to error out on these fields
+      return acc;
+    }
+
+    // ignore fields with '@' in the middle of the string
+    const normalizedField = normalizeAtField(failedItemName);
+    const normalizedExpansionField = sourceModelField ? normalizeAtField(sourceModelField) : null;
+    if (normalizedField !== failedItemName || (sourceModelField && sourceModelField !== normalizedExpansionField)) {
+      return acc;
+    }
+
+    let resolvedKeyword = keyword;
+    if (keyword === SCHEMA_ERROR_KEYWORDS.ERROR_MESSAGE) {
+      resolvedKeyword = params?.errors?.[0]?.keyword || keyword;
+    }
+
+    if (failedItemValue?.['constructor'] === Object && resolvedKeyword === SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) {
+      failedItemValue = SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES;
+    }
+
+    if (resolvedKeyword === SCHEMA_ERROR_KEYWORDS.MAX_LENGTH) {
+      if (isRCF) {
+        isWarning = true;
+      } else {
+        message = getMaxLengthMessage(
+          params?.errors?.find(e => e?.params?.limit),
+          isRCF
+        );
       }
-
-      if (['@odata', '@reso'].some(c => failedItemName.startsWith(c))) {
-        // we don't want to error out on these fields
-        return acc;
-      }
-
-      // ignore fields with '@' in the middle of the string
-      const normalizedField = normalizeAtField(failedItemName);
-      const normalizedExpansionField = sourceModelField ? normalizeAtField(sourceModelField) : null;
-      if (normalizedField !== failedItemName || (sourceModelField && sourceModelField !== normalizedExpansionField)) {
-        return acc;
-      }
-
-      let resolvedKeyword = keyword;
-      if (keyword === SCHEMA_ERROR_KEYWORDS.ERROR_MESSAGE) {
-        resolvedKeyword = params?.errors?.[0]?.keyword || keyword;
-      }
-
-      if (failedItemValue?.['constructor'] === Object && resolvedKeyword === SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) {
-        failedItemValue = SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES;
-      }
-
-      //sanitize params
-      [parsedResourceName, failedItemName].forEach(checkMapParams);
-
-      if (resolvedKeyword === SCHEMA_ERROR_KEYWORDS.MAX_LENGTH) {
-        if (isRCF) {
-          isWarning = true;
-        } else {
-          message = getMaxLengthMessage(
-            params?.errors?.find(e => e?.params?.limit),
-            isRCF
-          );
-        }
-      }
-      if (isWarning) {
-        updateCacheAndStats({
-          cache: warningsCache,
-          resourceName: parsedResourceName,
-          failedItemName,
-          message,
-          fileName,
-          stats,
-          failedItemValue,
-          isWarning,
-          sourceModel,
-          sourceModelField
-        });
-        return acc;
-      }
-
+    }
+    if (isWarning) {
       updateCacheAndStats({
-        cache: errorCache,
-        resourceName: parsedResourceName,
+        cache: warningsCache,
+        resourceName: resourceName,
         failedItemName,
         message,
         fileName,
         stats,
         failedItemValue,
+        isWarning,
         sourceModel,
         sourceModelField
       });
       return acc;
-    },
-    {}
-  );
+    }
+
+    updateCacheAndStats({
+      cache: errorCache,
+      resourceName: resourceName,
+      failedItemName,
+      message,
+      fileName,
+      stats,
+      failedItemValue,
+      sourceModel,
+      sourceModelField
+    });
+    return acc;
+  }, {});
 };
 
 module.exports = {

--- a/test/schema/payload-samples.js
+++ b/test/schema/payload-samples.js
@@ -406,6 +406,22 @@ const expansionErrorMultiValuePayload = {
   ]
 };
 
+const expansionIgnoredItem = {
+  '@reso.context': 'urn:reso:metadata:1.7:resource:property',
+  value: [
+    {
+      Country: 'CA',
+      StateOrProvince: 'ON',
+      City: 'SampleCityEnumValue',
+      PostalCode: 'K2G 1Y9',
+      StreetName: 'Starwood Rd',
+      StreetNumber: '39',
+      AboveGradeFinishedAreaSource: 'Appraiser',
+      Media: [{ ImageSizeDescription: 'Foo' }]
+    }
+  ]
+};
+
 module.exports = {
   valuePayload,
   nonValuePayload,
@@ -430,5 +446,6 @@ module.exports = {
   atFieldPayloadError,
   invalidOdataIdentifierInvalidPayload,
   validNonStringNonIsflagsPayload,
-  expansionErrorMultiValuePayload
+  expansionErrorMultiValuePayload,
+  expansionIgnoredItem
 };

--- a/test/schema/payload-samples.js
+++ b/test/schema/payload-samples.js
@@ -406,6 +406,28 @@ const expansionErrorMultiValuePayload = {
   ]
 };
 
+const collectionExpansionError = {
+  '@reso.context': 'urn:reso:metadata:1.7:resource:property',
+  value: [
+    {
+      Media: [
+        {
+          ChangedByMemberID: 'id'
+        },
+        {
+          ChangedByMemberID: 'id',
+          ImageHeight: 'foo'
+        }
+      ],
+      Country: 'CA',
+      StateOrProvince: 'ON',
+      PostalCode: 'K2G 1Y9',
+      StreetName: 'Starwood Rd',
+      StreetNumber: '39'
+    }
+  ]
+};
+
 const expansionIgnoredItem = {
   '@reso.context': 'urn:reso:metadata:1.7:resource:property',
   value: [
@@ -420,6 +442,18 @@ const expansionIgnoredItem = {
       Media: [{ ImageSizeDescription: 'Foo' }]
     }
   ]
+};
+
+const singleValueExpansionError = {
+  '@reso.context': 'urn:reso:metadata:1.7:resource:property',
+  Country: 'CA',
+  StateOrProvince: 'ON',
+  City: 'SampleCityEnumValue',
+  PostalCode: 'K2G 1Y9',
+  StreetName: 'Starwood Rd',
+  StreetNumber: '39',
+  AboveGradeFinishedAreaSource: 'Appraiser',
+  Media: [{ ImageSizeDescription: 'Foo' }]
 };
 
 module.exports = {
@@ -447,5 +481,7 @@ module.exports = {
   invalidOdataIdentifierInvalidPayload,
   validNonStringNonIsflagsPayload,
   expansionErrorMultiValuePayload,
-  expansionIgnoredItem
+  expansionIgnoredItem,
+  collectionExpansionError,
+  singleValueExpansionError
 };


### PR DESCRIPTION
closes #177

This PR fixes the issue from #177. It also adds new tests to cover some cases that weren't covered by tests. It adds new parsing for the nested schema error properties that does not rely on hardcoded array indices.