### PR TITLE
#195: Add keyfield and keys to schema validation error report

### DIFF
--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -524,7 +524,7 @@ const updateCacheAndStats = ({
     };
   } else {
     cache[resourceName][failedItemName][message][filePath][failedItemValue].occurrences++;
-    if (cache[resourceName][failedItemName][message][filePath][failedItemValue]?.keyFieldValue) {
+    if (cache[resourceName][failedItemName][message][filePath][failedItemValue]?.keys) {
       cache[resourceName][failedItemName][message][filePath][failedItemValue].keys.push(keyFieldValue);
     }
   }

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -399,17 +399,42 @@ const combineErrors = ({ errorCache, warningsCache, payloadErrors, stats, versio
           const occurrences = Object.entries(files).flatMap(([fileName, values]) => {
             const file = path.basename(fileName || '');
             const pathName = fileName;
-            return Object.entries(values).map(([lookupValue, details]) => ({
-              count: details.occurrences,
-              ...(file && { fileName: file }),
-              ...(pathName && { pathName }),
-              ...(details?.failedEnum != null && { lookupValue }),
-              ...(details?.sourceModel && { sourceModel: details.sourceModel }),
-              ...(details?.sourceModelField && { sourceModelField: details.sourceModelField }),
-              ...(details?.keyField && { keyField: details.keyField }),
-              ...(details?.keys && { keys: details.keys }),
-              message: details.message
-            }));
+            return Object.entries(values).map(([lookupValue, details]) => {
+              const result = {
+                count: details.occurrences,
+                message: details.message
+              };
+
+              if (file) {
+                result.fileName = file;
+              }
+
+              if (pathName) {
+                result.pathName = pathName;
+              }
+
+              if (details?.failedEnum != null) {
+                result.lookupValue = lookupValue;
+              }
+
+              if (details?.sourceModel) {
+                result.sourceModel = details.sourceModel;
+              }
+
+              if (details?.sourceModelField) {
+                result.sourceModelField = details.sourceModelField;
+              }
+
+              if (details?.keyField) {
+                result.keyField = details.keyField;
+              }
+
+              if (details?.keys) {
+                result.keys = details.keys;
+              }
+
+              return result;
+            });
           });
 
           const message = occurrences?.[0]?.message ?? '';
@@ -514,22 +539,29 @@ const updateCacheAndStats = ({
   }
 
   if (!cache[resourceName][failedItemName][message][filePath][failedItemValue]) {
-    cache[resourceName][failedItemName][message][filePath][failedItemValue] = {
+    const error = {
       // Capitalize first word like MUST, SHOULD, etc.
       message: !message.startsWith(isWarning ? 'The' : 'Fields')
         ? message.slice(0, message.indexOf(' ')).toUpperCase() + message.slice(message.indexOf(' '), message.length)
         : message,
       occurrences: 1,
       sourceModel,
-      sourceModelField,
-      ...(keyField && keyFieldValue && { keyField }),
-      ...(keyFieldValue && { keys: [keyFieldValue] }),
-      ...(failedEnum != null && { failedEnum })
+      sourceModelField
     };
+    if (keyField && keyFieldValue) {
+      error.keyField = keyField;
+    }
+    if (keyFieldValue) {
+      error.keys = [keyFieldValue];
+    }
+    if (failedEnum != null) {
+      error.failedEnum = failedEnum;
+    }
+    cache[resourceName][failedItemName][message][filePath][failedItemValue] = error;
   } else {
     cache[resourceName][failedItemName][message][filePath][failedItemValue].occurrences++;
-    if (cache[resourceName][failedItemName][message][filePath][failedItemValue]?.keys && keyFieldValue) {
-      cache[resourceName][failedItemName][message][filePath][failedItemValue].keys.push(keyFieldValue);
+    if (cache[resourceName]?.[failedItemName]?.[message]?.[filePath]?.[failedItemValue]?.keys && keyFieldValue) {
+      cache[resourceName]?.[failedItemName]?.[message]?.[filePath]?.[failedItemValue]?.keys.push(keyFieldValue);
     }
   }
 
@@ -582,7 +614,6 @@ const keyifyResourceName = resourceName => {
   return resourceName.trim() + 'Key';
 };
 
-// prettier-ignore
 const getKeyFieldForResource = resourceName => {
   switch (resourceName) {
   case 'Property':

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -131,7 +131,7 @@ const writeFile = async (path, data) => {
  * @param {string[]} obj.arr
  * @param {Object} obj.metadataMap
  * @param {string} obj.parentResourceName
- * @returns {{parentResourceName: string, sourceModel: string?, sourceModelField: string?, fieldName: string?}}
+ * @returns {{parentResourceName: string, sourceModel: string?, sourceModelField: string?, fieldName: string?, index: number?, expansionIndex: number?}}
  */
 const parseNestedPropertyForResourceAndField = ({ arr, metadataMap, parentResourceName }) => {
   return arr.reduce(
@@ -262,6 +262,7 @@ const addCustomValidationForEnum = ajv => {
           const errorMessage = {
             keyword: 'enum',
             failedItemValue: enumValue,
+            failedEnum: enumValue,
             params: {
               allowedValues: schema
             },
@@ -402,7 +403,7 @@ const combineErrors = ({ errorCache, warningsCache, payloadErrors, stats, versio
               count: details.occurrences,
               ...(file && { fileName: file }),
               ...(pathName && { pathName }),
-              ...(lookupValue && { lookupValue }),
+              ...(details?.failedEnum != null && { lookupValue }),
               ...(details?.sourceModel && { sourceModel: details.sourceModel }),
               ...(details?.sourceModelField && { sourceModelField: details.sourceModelField }),
               ...(details?.keyField && { keyField: details.keyField }),
@@ -474,6 +475,7 @@ const combineErrors = ({ errorCache, warningsCache, payloadErrors, stats, versio
  * @param {String} obj.sourceModelField
  * @param {String | null} obj.keyField
  * @param {String | null} obj.keyFieldValue
+ * @param {String?} obj.failedEnum
  * @param {{totalErrors: Number, totalWarnings: Number}} obj.stats
  * @param {boolean} obj.isWarning
  *
@@ -491,7 +493,8 @@ const updateCacheAndStats = ({
   sourceModel,
   sourceModelField,
   keyField,
-  keyFieldValue
+  keyFieldValue,
+  failedEnum
 }) => {
   const filePath = fileName;
   if (!cache[resourceName]) {
@@ -520,11 +523,12 @@ const updateCacheAndStats = ({
       sourceModel,
       sourceModelField,
       ...(keyField && keyFieldValue && { keyField }),
-      ...(keyFieldValue && { keys: [keyFieldValue] })
+      ...(keyFieldValue && { keys: [keyFieldValue] }),
+      ...(failedEnum != null && { failedEnum })
     };
   } else {
     cache[resourceName][failedItemName][message][filePath][failedItemValue].occurrences++;
-    if (cache[resourceName][failedItemName][message][filePath][failedItemValue]?.keys) {
+    if (cache[resourceName][failedItemName][message][filePath][failedItemValue]?.keys && keyFieldValue) {
       cache[resourceName][failedItemName][message][filePath][failedItemValue].keys.push(keyFieldValue);
     }
   }

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -554,7 +554,7 @@ const updateCacheAndStats = ({
     if (keyFieldValue) {
       error.keys = [keyFieldValue];
     }
-    if (failedEnum != null) {
+    if (failedEnum !== null && failedEnum !== undefined) {
       error.failedEnum = failedEnum;
     }
     cache[resourceName][failedItemName][message][filePath][failedItemValue] = error;

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -160,11 +160,24 @@ const parseNestedPropertyForResourceAndField = ({ arr, metadataMap, parentResour
             fieldName: field
           };
         }
+      } else if (!isNaN(Number(field))) {
+        if (acc.index === null) {
+          return {
+            ...acc,
+            index: Number(field)
+          };
+        } else if (acc.expansionIndex === null) {
+          return {
+            ...acc,
+            expansionIndex: Number(field)
+          };
+        }
+        return acc;
       } else {
         return acc;
       }
     },
-    { parentResourceName, sourceModel: null, sourceModelField: null, fieldName: null }
+    { parentResourceName, sourceModel: null, sourceModelField: null, fieldName: null, index: null, expansionIndex: null }
   );
 };
 
@@ -392,6 +405,8 @@ const combineErrors = ({ errorCache, warningsCache, payloadErrors, stats, versio
               ...(lookupValue && { lookupValue }),
               ...(details?.sourceModel && { sourceModel: details.sourceModel }),
               ...(details?.sourceModelField && { sourceModelField: details.sourceModelField }),
+              ...(details?.keyField && { keyField: details.keyField }),
+              ...(details?.keys && { keys: details.keys }),
               message: details.message
             }));
           });
@@ -457,6 +472,8 @@ const combineErrors = ({ errorCache, warningsCache, payloadErrors, stats, versio
  * @param {String} obj.fileName
  * @param {String} obj.sourceModel
  * @param {String} obj.sourceModelField
+ * @param {String | null} obj.keyField
+ * @param {String | null} obj.keyFieldValue
  * @param {{totalErrors: Number, totalWarnings: Number}} obj.stats
  * @param {boolean} obj.isWarning
  *
@@ -472,7 +489,9 @@ const updateCacheAndStats = ({
   failedItemValue,
   isWarning,
   sourceModel,
-  sourceModelField
+  sourceModelField,
+  keyField,
+  keyFieldValue
 }) => {
   const filePath = fileName;
   if (!cache[resourceName]) {
@@ -499,10 +518,15 @@ const updateCacheAndStats = ({
         : message,
       occurrences: 1,
       sourceModel,
-      sourceModelField
+      sourceModelField,
+      ...(keyField && keyFieldValue && { keyField }),
+      ...(keyFieldValue && { keys: [keyFieldValue] })
     };
   } else {
     cache[resourceName][failedItemName][message][filePath][failedItemValue].occurrences++;
+    if (cache[resourceName][failedItemName][message][filePath][failedItemValue]?.keyFieldValue) {
+      cache[resourceName][failedItemName][message][filePath][failedItemValue].keys.push(keyFieldValue);
+    }
   }
 
   if (isWarning) {
@@ -550,6 +574,76 @@ const getMaxLengthMessage = (limitObject, isRCF) => {
   }
 };
 
+const keyifyResourceName = resourceName => {
+  return resourceName.trim() + 'Key';
+};
+
+// prettier-ignore
+const getKeyFieldForResource = resourceName => {
+  switch (resourceName) {
+  case 'Property':
+    return 'ListingKey';
+  case 'Contacts':
+  case 'ContactListingNotes':
+    return 'ContactKey';
+  case 'InternetTracking':
+    return 'EventKey';
+  case 'InternetTrackingSummary':
+    return 'ListingId';
+  case 'OUID':
+    return 'OrganizationUniqueIdKey';
+  case 'Queue':
+    return 'QueueTransactionKey';
+  case 'PropertyGreenVerification':
+    return 'GreenBuildingVerificationKey';
+  case 'PropertyRooms':
+    return 'RoomKey';
+  case 'PropertyUnitTypes':
+    return 'UnitTypeKey';
+  case 'EntityEvent':
+    return 'EntityEventSequence';
+  case 'MemberAssociation':
+  case 'OfficeAssociation':
+    return 'AssociationKey';
+  case 'TransactionManagement':
+    return 'TransactionKey';
+  case 'Rules':
+    return 'RuleKey';
+  case 'Teams':
+    return 'TeamKey';
+  case 'TeamMembers':
+    return 'TeamMemberKey';
+  case 'PropertyPowerProduction':
+    return 'PowerProductionKey';
+  case 'PropertyPowerStorage':
+    return 'PowerStorageKey';
+  default:
+    return keyifyResourceName(resourceName);
+  }
+};
+
+const getValueForKeyField = ({ keyField, payload, index, expansionIndex, expansionField, isExpansion }) => {
+  if (isExpansion) {
+    if (index != null) {
+      let keyValue;
+      if (expansionIndex != null) {
+        keyValue = payload?.value?.[index]?.[expansionField]?.[expansionIndex]?.[keyField];
+      } else {
+        keyValue = payload?.value?.[index]?.[expansionField]?.[keyField];
+      }
+      if (keyValue) return keyValue;
+    }
+  } else {
+    if (index != null) {
+      const keyValue = payload?.value?.[index]?.[keyField];
+      if (keyValue) {
+        return keyValue;
+      }
+    }
+  }
+  return null;
+};
+
 module.exports = {
   processFiles,
   readFile,
@@ -567,5 +661,7 @@ module.exports = {
   combineErrors,
   updateCacheAndStats,
   getResourceAndVersion,
-  getMaxLengthMessage
+  getMaxLengthMessage,
+  getKeyFieldForResource,
+  getValueForKeyField
 };

--- a/lib/schema/utils.js
+++ b/lib/schema/utils.js
@@ -8,6 +8,11 @@ const { validationContext } = require('./context');
 
 const IGNORE_ENUMS = 'ignoreEnumerations';
 
+const isReservedKey = key => {
+  const reservedKeys = ['__proto__', 'constructor', 'prototype'];
+  return reservedKeys.includes(key);
+};
+
 /**
  * @param {Object} obj
  * @param {string} obj.inputPath
@@ -522,6 +527,10 @@ const updateCacheAndStats = ({
   failedEnum
 }) => {
   const filePath = fileName;
+  if (isReservedKey(filePath)) {
+    return;
+  }
+
   if (!cache[resourceName]) {
     cache[resourceName] = {};
   }
@@ -698,5 +707,6 @@ module.exports = {
   getResourceAndVersion,
   getMaxLengthMessage,
   getKeyFieldForResource,
-  getValueForKeyField
+  getValueForKeyField,
+  isReservedKey
 };

--- a/lib/schema/validate.js
+++ b/lib/schema/validate.js
@@ -365,8 +365,8 @@ const generateErrorReport = ({
 
     const multiPayload = validationContext.getPayloadType() === 'MULTI';
     const payload = multiPayload ? json : { value: [json] };
-    const keyField = getKeyFieldForResource(sourceModel || resourceName);
-    const keyFieldValue = getValueForKeyField({
+    const keyField = isWarning ? null : getKeyFieldForResource(sourceModel || resourceName);
+    const keyFieldValue = isWarning ? null : getValueForKeyField({
       keyField,
       payload,
       index: multiPayload ? index : 0,

--- a/lib/schema/validate.js
+++ b/lib/schema/validate.js
@@ -272,7 +272,7 @@ const generateErrorReport = ({
   isRCF,
   metadataMap
 }) => {
-  validate.errors.reduce((acc, { instancePath, message, keyword, params, failedItemValue: value, isWarning, transformedValue }) => {
+  validate.errors.reduce((acc, { instancePath, message, keyword, params, failedItemValue: value, isWarning, transformedValue, failedEnum }) => {
     if (!instancePath && keyword !== SCHEMA_ERROR_KEYWORDS.ADDITIONAL_PROPERTIES) return acc;
     const nestedPayloadProperties = instancePath?.split('/')?.slice(1) || [];
     let failedItemValue = '';
@@ -352,6 +352,7 @@ const generateErrorReport = ({
     }
 
     if (resolvedKeyword === SCHEMA_ERROR_KEYWORDS.MAX_LENGTH) {
+      failedItemValue = '';
       if (isRCF) {
         isWarning = true;
       } else {
@@ -386,7 +387,8 @@ const generateErrorReport = ({
       sourceModel,
       sourceModelField,
       keyField,
-      keyFieldValue
+      keyFieldValue,
+      failedEnum
     });
     return acc;
   }, {});

--- a/lib/schema/validate.js
+++ b/lib/schema/validate.js
@@ -297,12 +297,12 @@ const generateErrorReport = ({
       failedItemValue = '';
     }
 
-    // eslint-disable-next-line prefer-const
-    let { fieldName, sourceModel, sourceModelField, index, expansionIndex } = parseNestedPropertyForResourceAndField({
+    const { fieldName, sourceModel, sourceModelField: modelField, index, expansionIndex } = parseNestedPropertyForResourceAndField({
       arr: nestedPayloadProperties,
       metadataMap: schema?.definitions?.MetadataMap,
       parentResourceName: resourceName
     });
+    let sourceModelField = modelField;
 
     if (
       keyword === SCHEMA_ERROR_KEYWORDS.TYPE &&
@@ -365,7 +365,7 @@ const generateErrorReport = ({
 
     const multiPayload = validationContext.getPayloadType() === 'MULTI';
     const payload = multiPayload ? json : { value: [json] };
-    const keyField = isWarning ? null : getKeyFieldForResource(sourceModel || resourceName);
+    const keyField = isWarning ? null : getKeyFieldForResource(sourceModel ?? resourceName);
     const keyFieldValue = isWarning ? null : getValueForKeyField({
       keyField,
       payload,

--- a/lib/schema/validate.js
+++ b/lib/schema/validate.js
@@ -18,7 +18,9 @@ const {
   getResourceAndVersion,
   getMaxLengthMessage,
   VALIDATION_ERROR_MESSAGES,
-  SCHEMA_ERROR_KEYWORDS
+  SCHEMA_ERROR_KEYWORDS,
+  getKeyFieldForResource,
+  getValueForKeyField
 } = require('./utils');
 const { validationContext } = require('./context');
 
@@ -296,7 +298,7 @@ const generateErrorReport = ({
     }
 
     // eslint-disable-next-line prefer-const
-    let { fieldName, sourceModel, sourceModelField } = parseNestedPropertyForResourceAndField({
+    let { fieldName, sourceModel, sourceModelField, index, expansionIndex } = parseNestedPropertyForResourceAndField({
       arr: nestedPayloadProperties,
       metadataMap: schema?.definitions?.MetadataMap,
       parentResourceName: resourceName
@@ -360,6 +362,18 @@ const generateErrorReport = ({
       }
     }
 
+    const multiPayload = validationContext.getPayloadType() === 'MULTI';
+    const payload = multiPayload ? json : { value: [json] };
+    const keyField = getKeyFieldForResource(sourceModel || resourceName);
+    const keyFieldValue = getValueForKeyField({
+      keyField,
+      payload,
+      index: multiPayload ? index : 0,
+      expansionIndex: multiPayload ? expansionIndex : index,
+      expansionField: failedItemName,
+      isExpansion: !!sourceModel
+    });
+
     updateCacheAndStats({
       cache: isWarning ? warningsCache : errorCache,
       resourceName: resourceName,
@@ -370,7 +384,9 @@ const generateErrorReport = ({
       failedItemValue,
       isWarning,
       sourceModel,
-      sourceModelField
+      sourceModelField,
+      keyField,
+      keyFieldValue
     });
     return acc;
   }, {});

--- a/test/schema/payload-samples.js
+++ b/test/schema/payload-samples.js
@@ -472,6 +472,50 @@ const topLevelUnadvertisedField = {
   Foo: false
 };
 
+const keyFieldPayloadMulti = {
+  '@reso.context': 'urn:reso:metadata:1.7:resource:property',
+  value: [
+    {
+      Country: 'CA',
+      StateOrProvince: 'ON',
+      City: 'NYC',
+      ListingKey: 'listingkey1',
+      Media: [
+        {
+          ResourceName: 'Property',
+          MediaCategory: 'Branded Virtual Tour',
+          MediaURL: 'https://example.com/vJVDL415WZ7GE1/',
+          ShortDescription: 'Example',
+          MediaKey: 'mediakey1'
+        },
+        {
+          ResourceName: 'Property',
+          MediaCategory: 'Branded Virtual Tour',
+          MediaURL: 'https://example.com/vJVDL415WZ7GE1/doc/floorplan_imperial.pdf',
+          ShortDescription: 'imperial',
+          MediaKey: 'mediakey2'
+        }
+      ],
+      Rooms: [
+        {
+          RoomWidth: 4.409,
+          RoomLength: 2.977,
+          RoomLengthWidthUnits: 'Meters',
+          RoomKey: 'roomkey1',
+          RoomLengthWidthSource: 'LocalProvider'
+        },
+        {
+          RoomWidth: 4.3,
+          RoomLength: 5.998,
+          RoomLengthWidthUnits: 'Meters',
+          RoomKey: 'roomkey2',
+          RoomLengthWidthSource: 'LocalProvider'
+        }
+      ]
+    }
+  ]
+};
+
 module.exports = {
   valuePayload,
   nonValuePayload,
@@ -500,5 +544,6 @@ module.exports = {
   expansionIgnoredItem,
   collectionExpansionError,
   singleValueExpansionError,
-  topLevelUnadvertisedField
+  topLevelUnadvertisedField,
+  keyFieldPayloadMulti
 };


### PR DESCRIPTION
closes #195 

also adds `lookupValue` in case the failed enum was an empty string.