### PR TITLE
#198: Updated Container Defaults for DockerfileBullseye

### DIFF
--- a/DockerfileBullseye
+++ b/DockerfileBullseye
@@ -10,6 +10,7 @@ RUN rm -rf web-api-commander/.git
 RUN rm -rf /var/lib/apt/lists/*
 
 ENV WEB_API_COMMANDER_PATH=/web-api-commander
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 ENV REFERENCE_METADATA_URL=https://services.reso.org/metadata
 ENV NODE_OPTIONS=--max-old-space-size=8192
 ADD ./ ./


### PR DESCRIPTION
Added default encoding of UTF-8 for the version of Java running in the container.